### PR TITLE
Protect move fixes

### DIFF
--- a/src/gen2/choice_effects.rs
+++ b/src/gen2/choice_effects.rs
@@ -62,11 +62,8 @@ pub fn modify_choice(
             }
         }
         Choices::PROTECT => {
-            if attacking_side.side_conditions.protect > 0 {
-                // for now, the engine doesn't support consecutive protects
-                // 2nd protect will always fail
-                attacker_choice.volatile_status = None;
-            }
+            // A probabilistic fail chance (halving toward 0) is applied
+            // in generate_instructions_from_existing_status_conditions.
         }
         Choices::PURSUIT => {
             if defender_choice.category == MoveCategory::Switch {

--- a/src/gen2/generate_instructions.rs
+++ b/src/gen2/generate_instructions.rs
@@ -40,6 +40,10 @@ use crate::{
 use std::cmp;
 
 pub const MAX_SLEEP_TURNS: i8 = 6;
+// In gen 2 the success chance of Protect/Detect halves per prior consecutive use and tends
+// to 0 (255 -> 127 -> 63 ... -> 1/255, then always fails). There is no floor, so this chance is applied without clamping. `(1/2)^n` approximates
+// the cartridge's integer halving of 255.
+pub const CONSECUTIVE_PROTECT_CHANCE: f32 = 1.0 / 2.0;
 pub const SANDSTORM_PERCENT_DAMAGE: f32 = 0.125;
 pub const BURN_PERCENT_DAMAGE: f32 = 0.125;
 pub const TRAPPED_PERCENT_DAMAGE: f32 = 0.0625;
@@ -1317,6 +1321,19 @@ fn generate_instructions_from_existing_status_conditions(
         final_instructions.push(hit_yourself_instruction);
 
         incoming_instructions.update_percentage(0.50);
+    }
+
+    if attacking_side.side_conditions.protect > 0 {
+        if let Some(vs) = &attacker_choice.volatile_status {
+            if vs.volatile_status == PokemonVolatileStatus::PROTECT {
+                let protect_success_chance =
+                    CONSECUTIVE_PROTECT_CHANCE.powi(attacking_side.side_conditions.protect as i32);
+                let mut protect_fail_instruction = incoming_instructions.clone();
+                protect_fail_instruction.update_percentage(1.0 - protect_success_chance);
+                final_instructions.push(protect_fail_instruction);
+                incoming_instructions.update_percentage(protect_success_chance);
+            }
+        }
     }
 }
 

--- a/src/gen3/generate_instructions.rs
+++ b/src/gen3/generate_instructions.rs
@@ -43,6 +43,8 @@ pub const BASE_CRIT_CHANCE: f32 = 1.0 / 16.0;
 pub const MAX_SLEEP_TURNS: i8 = 4;
 pub const HIT_SELF_IN_CONFUSION_CHANCE: f32 = 1.0 / 2.0;
 pub const CONSECUTIVE_PROTECT_CHANCE: f32 = 1.0 / 2.0;
+// Success chance halves per prior consecutive use down to a floor of 1/8
+pub const CONSECUTIVE_PROTECT_MIN_CHANCE: f32 = 1.0 / 8.0;
 pub const SIDE_CONDITION_DURATION: i8 = 5;
 
 const PROTECT_VOLATILES: [PokemonVolatileStatus; 2] = [
@@ -1458,8 +1460,9 @@ fn generate_instructions_from_existing_status_conditions(
     if attacking_side.side_conditions.protect > 0 {
         if let Some(vs) = &attacker_choice.volatile_status {
             if PROTECT_VOLATILES.contains(&vs.volatile_status) {
-                let protect_success_chance =
-                    CONSECUTIVE_PROTECT_CHANCE.powi(attacking_side.side_conditions.protect as i32);
+                let protect_success_chance = CONSECUTIVE_PROTECT_CHANCE
+                    .powi(attacking_side.side_conditions.protect as i32)
+                    .max(CONSECUTIVE_PROTECT_MIN_CHANCE);
                 let mut protect_fail_instruction = incoming_instructions.clone();
                 protect_fail_instruction.update_percentage(1.0 - protect_success_chance);
                 final_instructions.push(protect_fail_instruction);

--- a/src/genx/generate_instructions.rs
+++ b/src/genx/generate_instructions.rs
@@ -107,6 +107,23 @@ pub const CONSECUTIVE_PROTECT_CHANCE: f32 = 1.0 / 3.0;
 #[cfg(any(feature = "gen4"))]
 pub const CONSECUTIVE_PROTECT_CHANCE: f32 = 1.0 / 2.0;
 
+// The consecutive-Protect success chance does not decrease without bound: the games clamp
+// it at a floor. From gen 5 on the chance is 1/3 per prior use with a floor of 1/729
+// (reached on the 7th consecutive use, i.e. protect counter 6); in gen 4 it is 1/2 per use
+// with a floor of 1/8 (4th use, counter 3).
+#[cfg(any(
+    feature = "gen5",
+    feature = "gen6",
+    feature = "gen7",
+    feature = "gen8",
+    feature = "gen9",
+    feature = "champions"
+))]
+pub const CONSECUTIVE_PROTECT_MIN_CHANCE: f32 = 1.0 / 729.0;
+
+#[cfg(any(feature = "gen4"))]
+pub const CONSECUTIVE_PROTECT_MIN_CHANCE: f32 = 1.0 / 8.0;
+
 #[cfg(any(feature = "gen4", feature = "gen5", feature = "gen6"))]
 pub const PARALYSIS_SPEED_MULTIPLIER: f32 = 0.25;
 
@@ -2003,8 +2020,9 @@ fn generate_instructions_from_existing_status_conditions(
     if attacking_side.side_conditions.protect > 0 {
         if let Some(vs) = &attacker_choice.volatile_status {
             if PROTECT_VOLATILES.contains(&vs.volatile_status) {
-                let protect_success_chance =
-                    CONSECUTIVE_PROTECT_CHANCE.powi(attacking_side.side_conditions.protect as i32);
+                let protect_success_chance = CONSECUTIVE_PROTECT_CHANCE
+                    .powi(attacking_side.side_conditions.protect as i32)
+                    .max(CONSECUTIVE_PROTECT_MIN_CHANCE);
                 let mut protect_fail_instruction = incoming_instructions.clone();
                 protect_fail_instruction.update_percentage(1.0 - protect_success_chance);
                 final_instructions.push(protect_fail_instruction);

--- a/src/genx/generate_instructions.rs
+++ b/src/genx/generate_instructions.rs
@@ -107,10 +107,7 @@ pub const CONSECUTIVE_PROTECT_CHANCE: f32 = 1.0 / 3.0;
 #[cfg(any(feature = "gen4"))]
 pub const CONSECUTIVE_PROTECT_CHANCE: f32 = 1.0 / 2.0;
 
-// The consecutive-Protect success chance does not decrease without bound: the games clamp
-// it at a floor. From gen 5 on the chance is 1/3 per prior use with a floor of 1/729
-// (reached on the 7th consecutive use, i.e. protect counter 6); in gen 4 it is 1/2 per use
-// with a floor of 1/8 (4th use, counter 3).
+// Floor for the consecutive-Protect success chance: 1/729 for gens 5+, 1/8 for gen 4.
 #[cfg(any(
     feature = "gen5",
     feature = "gen6",

--- a/tests/test_battle_mechanics.rs
+++ b/tests/test_battle_mechanics.rs
@@ -2675,6 +2675,66 @@ fn test_protect_for_second_turn_in_a_row() {
     assert_eq!(expected_instructions, vec_of_instructions);
 }
 
+// The consecutive-Protect success chance is clamped at the per-generation floor. These
+// tests pin the LITERAL floored value at a deep chain, rather than recomputing it from
+// CONSECUTIVE_PROTECT_CHANCE (which would be self-referential and could not catch the
+// missing clamp). The success branch is the one that keeps Protect up.
+fn consecutive_protect_success_percentage(protect_stack: i8) -> f32 {
+    let mut state = State::default();
+    state.side_one.side_conditions.protect = protect_stack;
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::PROTECT,
+        Choices::TACKLE,
+    );
+    let success = vec_of_instructions
+        .iter()
+        .find(|si| {
+            si.instruction_list.iter().any(|i| {
+                matches!(
+                    i,
+                    Instruction::ApplyVolatileStatus(a)
+                        if a.volatile_status == PokemonVolatileStatus::PROTECT
+                )
+            })
+        })
+        .expect("a branch in which Protect succeeds");
+    success.percentage
+}
+
+#[cfg(feature = "gen4")]
+#[test]
+fn test_consecutive_protect_success_is_floored_at_one_eighth() {
+    // 5th consecutive Protect (stack 4). Unclamped (1/2)^4 = 1/16 = 6.25%; the real gen-4
+    // floor is 1/8 = 12.5%, reached from the 4th use onward.
+    let success = consecutive_protect_success_percentage(4);
+    assert!(
+        (success - 100.0 / 8.0).abs() < 1e-4,
+        "expected the gen-4 success chance to be floored at 1/8, got {}%",
+        success
+    );
+}
+
+#[cfg(any(
+    feature = "gen5",
+    feature = "gen6",
+    feature = "gen7",
+    feature = "gen8",
+    feature = "gen9",
+    feature = "champions"
+))]
+#[test]
+fn test_consecutive_protect_success_is_floored_at_one_over_729() {
+    // 8th consecutive Protect (stack 7). Unclamped (1/3)^7 ~= 0.0457%; the real gen-5+
+    // floor is 1/729 ~= 0.137%, reached from the 7th use onward.
+    let success = consecutive_protect_success_percentage(7);
+    assert!(
+        (success - 100.0 / 729.0).abs() < 1e-4,
+        "expected the gen-5+ success chance to be floored at 1/729, got {}%",
+        success
+    );
+}
+
 #[test]
 fn test_regular_move_with_protect_side_condition() {
     let mut state = State::default();

--- a/tests/test_battle_mechanics.rs
+++ b/tests/test_battle_mechanics.rs
@@ -2675,10 +2675,9 @@ fn test_protect_for_second_turn_in_a_row() {
     assert_eq!(expected_instructions, vec_of_instructions);
 }
 
-// The consecutive-Protect success chance is clamped at the per-generation floor. These
-// tests pin the LITERAL floored value at a deep chain, rather than recomputing it from
-// CONSECUTIVE_PROTECT_CHANCE (which would be self-referential and could not catch the
-// missing clamp). The success branch is the one that keeps Protect up.
+// Pin the LITERAL floored value at a deep chain, rather than recomputing it from
+// CONSECUTIVE_PROTECT_CHANCE (self-referential, could not catch a missing clamp). The
+// success branch is the one that keeps Protect up.
 fn consecutive_protect_success_percentage(protect_stack: i8) -> f32 {
     let mut state = State::default();
     state.side_one.side_conditions.protect = protect_stack;

--- a/tests/test_gen2.rs
+++ b/tests/test_gen2.rs
@@ -1536,3 +1536,31 @@ fn test_mustrecharge_move_only_allows_none() {
     );
     assert_eq!(expected_options, options);
 }
+
+#[test]
+fn test_consecutive_protect_applies_halving_chance_with_no_floor() {
+    let mut state = State::default();
+    state.side_one.side_conditions.protect = 4;
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::PROTECT,
+        Choices::TACKLE,
+    );
+    let success = vec_of_instructions
+        .iter()
+        .find(|si| {
+            si.instruction_list.iter().any(|i| {
+                matches!(
+                    i,
+                    Instruction::ApplyVolatileStatus(a)
+                        if a.volatile_status == PokemonVolatileStatus::PROTECT
+                )
+            })
+        })
+        .expect("a branch in which Protect succeeds");
+    assert!(
+        (success.percentage - 100.0 / 16.0).abs() < 1e-4,
+        "expected gen-2 success chance (1/2)^4 = 6.25% with no floor, got {}%",
+        success.percentage
+    );
+}

--- a/tests/test_gen3.rs
+++ b/tests/test_gen3.rs
@@ -580,3 +580,34 @@ fn test_gen3_branch_when_a_roll_can_kill() {
     ];
     assert_eq!(expected_instructions, vec_of_instructions);
 }
+
+#[test]
+fn test_consecutive_protect_success_is_floored_at_one_eighth() {
+    // 5th consecutive Protect (stack 4). Unclamped (1/2)^4 = 1/16 = 6.25%; the real gen-3
+    // floor is 1/8 = 12.5% (4th use onward). Pins the literal floored value so it is not
+    // self-referential with CONSECUTIVE_PROTECT_CHANCE.
+    let mut state = State::default();
+    state.side_one.side_conditions.protect = 4;
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::PROTECT,
+        Choices::TACKLE,
+    );
+    let success = vec_of_instructions
+        .iter()
+        .find(|si| {
+            si.instruction_list.iter().any(|i| {
+                matches!(
+                    i,
+                    Instruction::ApplyVolatileStatus(a)
+                        if a.volatile_status == PokemonVolatileStatus::PROTECT
+                )
+            })
+        })
+        .expect("a branch in which Protect succeeds");
+    assert!(
+        (success.percentage - 100.0 / 8.0).abs() < 1e-4,
+        "expected the gen-3 success chance to be floored at 1/8, got {}%",
+        success.percentage
+    );
+}


### PR DESCRIPTION
Hey, thanks a lot for the engine !

Here are few fixes for the `protect` move if you are interested:

- gen 2: instead of missing on consecutive -> halves the probability towards 0
- gen 3-4: instead of an unbounded 1/2ⁿ chance to activate -> floored at 1/8
- gen 5-9: instead of an unbounded 1/2ⁿ chance to activate -> floored at 1/729

based on https://bulbapedia.bulbagarden.net/wiki/Protect_(move)


Also, side question, would you potentially be interested in a const generics version of the engine to be able to serve all 9 generations from 1 binary (at no additional runtime cost) ? (I've got a branch here if interested https://github.com/Henauxg/poke-engine-fork/tree/const-generic-gens)