### PR TITLE
Implement some missing status berries

### DIFF
--- a/src/gen3/items.rs
+++ b/src/gen3/items.rs
@@ -124,8 +124,12 @@ define_enum_with_from_str! {
         PIXIEPLATE,
         LIGHTBALL,
         FOCUSSASH,
+        ASPEARBERRY,
+        CHERIBERRY,
         CHESTOBERRY,
         LUMBERRY,
+        PECHABERRY,
+        RAWSTBERRY,
         SITRUSBERRY,
         PETAYABERRY,
         SALACBERRY,
@@ -251,7 +255,11 @@ fn sitrus_berry(
     active_pkmn.item = Items::NONE;
 }
 
-fn chesto_berry(
+// A single-status-cure berry (Cheri/Chesto/Aspear/Pecha/Rawst): consume the berry and
+// remove the active Pokemon's status. The caller's match guard ensures the held status is
+// the one this berry cures, so `add_remove_status_instructions` removes the right status.
+fn status_cure_berry(
+    berry: Items,
     side_ref: &SideReference,
     attacking_side: &mut Side,
     instructions: &mut StateInstructions,
@@ -262,7 +270,7 @@ fn chesto_berry(
         .instruction_list
         .push(Instruction::ChangeItem(ChangeItemInstruction {
             side_ref: *side_ref,
-            current_item: Items::CHESTOBERRY,
+            current_item: berry,
             new_item: Items::NONE,
         }));
     active_pkmn.item = Items::NONE;
@@ -341,8 +349,23 @@ pub fn item_end_of_turn(
         Items::SITRUSBERRY if active_pkmn.hp <= active_pkmn.maxhp / 2 => {
             sitrus_berry(side_ref, attacking_side, instructions)
         }
+        Items::ASPEARBERRY if active_pkmn.status == PokemonStatus::FREEZE => {
+            status_cure_berry(Items::ASPEARBERRY, side_ref, attacking_side, instructions)
+        }
+        Items::CHERIBERRY if active_pkmn.status == PokemonStatus::PARALYZE => {
+            status_cure_berry(Items::CHERIBERRY, side_ref, attacking_side, instructions)
+        }
         Items::CHESTOBERRY if active_pkmn.status == PokemonStatus::SLEEP => {
-            chesto_berry(side_ref, attacking_side, instructions)
+            status_cure_berry(Items::CHESTOBERRY, side_ref, attacking_side, instructions)
+        }
+        Items::PECHABERRY
+            if active_pkmn.status == PokemonStatus::POISON
+                || active_pkmn.status == PokemonStatus::TOXIC =>
+        {
+            status_cure_berry(Items::PECHABERRY, side_ref, attacking_side, instructions)
+        }
+        Items::RAWSTBERRY if active_pkmn.status == PokemonStatus::BURN => {
+            status_cure_berry(Items::RAWSTBERRY, side_ref, attacking_side, instructions)
         }
         Items::LEFTOVERS => {
             let attacker = state.get_side(side_ref).get_active();

--- a/src/genx/items.rs
+++ b/src/genx/items.rs
@@ -132,8 +132,12 @@ define_enum_with_from_str! {
         PIXIEPLATE,
         LIGHTBALL,
         FOCUSSASH,
+        ASPEARBERRY,
+        CHERIBERRY,
         CHESTOBERRY,
         LUMBERRY,
+        PECHABERRY,
+        RAWSTBERRY,
         SITRUSBERRY,
         PETAYABERRY,
         SALACBERRY,
@@ -397,7 +401,11 @@ fn sitrus_berry(
     active_pkmn.item = Items::NONE;
 }
 
-fn chesto_berry(
+// A single-status-cure berry (Cheri/Chesto/Aspear/Pecha/Rawst): consume the berry and
+// remove the active Pokemon's status. The caller's match guard ensures the held status is
+// the one this berry cures, so `add_remove_status_instructions` removes the right status.
+fn status_cure_berry(
+    berry: Items,
     side_ref: &SideReference,
     attacking_side: &mut Side,
     instructions: &mut StateInstructions,
@@ -408,7 +416,7 @@ fn chesto_berry(
         .instruction_list
         .push(Instruction::ChangeItem(ChangeItemInstruction {
             side_ref: *side_ref,
-            current_item: Items::CHESTOBERRY,
+            current_item: berry,
             new_item: Items::NONE,
         }));
     active_pkmn.item = Items::NONE;
@@ -741,8 +749,23 @@ pub fn item_before_move(
         Items::SITRUSBERRY if active_pkmn.hp <= active_pkmn.maxhp / 4 => {
             sitrus_berry(side_ref, attacking_side, instructions)
         }
+        Items::ASPEARBERRY if active_pkmn.status == PokemonStatus::FREEZE => {
+            status_cure_berry(Items::ASPEARBERRY, side_ref, attacking_side, instructions)
+        }
+        Items::CHERIBERRY if active_pkmn.status == PokemonStatus::PARALYZE => {
+            status_cure_berry(Items::CHERIBERRY, side_ref, attacking_side, instructions)
+        }
         Items::CHESTOBERRY if active_pkmn.status == PokemonStatus::SLEEP => {
-            chesto_berry(side_ref, attacking_side, instructions)
+            status_cure_berry(Items::CHESTOBERRY, side_ref, attacking_side, instructions)
+        }
+        Items::PECHABERRY
+            if active_pkmn.status == PokemonStatus::POISON
+                || active_pkmn.status == PokemonStatus::TOXIC =>
+        {
+            status_cure_berry(Items::PECHABERRY, side_ref, attacking_side, instructions)
+        }
+        Items::RAWSTBERRY if active_pkmn.status == PokemonStatus::BURN => {
+            status_cure_berry(Items::RAWSTBERRY, side_ref, attacking_side, instructions)
         }
         Items::PETAYABERRY if active_pkmn.hp <= active_pkmn.maxhp / 4 => boost_berry(
             side_ref,
@@ -881,8 +904,23 @@ pub fn item_end_of_turn(
         Items::SITRUSBERRY if active_pkmn.hp <= active_pkmn.maxhp / 2 => {
             sitrus_berry(side_ref, attacking_side, instructions)
         }
+        Items::ASPEARBERRY if active_pkmn.status == PokemonStatus::FREEZE => {
+            status_cure_berry(Items::ASPEARBERRY, side_ref, attacking_side, instructions)
+        }
+        Items::CHERIBERRY if active_pkmn.status == PokemonStatus::PARALYZE => {
+            status_cure_berry(Items::CHERIBERRY, side_ref, attacking_side, instructions)
+        }
         Items::CHESTOBERRY if active_pkmn.status == PokemonStatus::SLEEP => {
-            chesto_berry(side_ref, attacking_side, instructions)
+            status_cure_berry(Items::CHESTOBERRY, side_ref, attacking_side, instructions)
+        }
+        Items::PECHABERRY
+            if active_pkmn.status == PokemonStatus::POISON
+                || active_pkmn.status == PokemonStatus::TOXIC =>
+        {
+            status_cure_berry(Items::PECHABERRY, side_ref, attacking_side, instructions)
+        }
+        Items::RAWSTBERRY if active_pkmn.status == PokemonStatus::BURN => {
+            status_cure_berry(Items::RAWSTBERRY, side_ref, attacking_side, instructions)
         }
         Items::BLACKSLUDGE => {
             if active_pkmn.has_type(&PokemonType::POISON) {

--- a/tests/test_battle_mechanics.rs
+++ b/tests/test_battle_mechanics.rs
@@ -22150,3 +22150,63 @@ fn test_mustrecharge_move_only_allows_none() {
     );
     assert_eq!(expected_options, options);
 }
+
+// Single-status-cure berries. Each consumes itself and removes exactly the status it
+// cures. Assert on the resulting state (every branch), so the tests are robust to any
+// status branching (freeze thaw, full paralysis) rather than pinning instruction lists.
+fn assert_status_cure_berry(berry: Items, status: PokemonStatus) {
+    let mut state = State::default();
+    state.side_one.get_active().item = berry;
+    state.side_one.get_active().status = status;
+
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::SPLASH,
+        Choices::SPLASH,
+    );
+
+    assert!(!vec_of_instructions.is_empty());
+    for si in &vec_of_instructions {
+        let mut branch = state.clone();
+        branch.apply_instructions(&si.instruction_list);
+        let active = branch.side_one.get_active_immutable();
+        assert_eq!(
+            PokemonStatus::NONE,
+            active.status,
+            "{:?} should have cured {:?}",
+            berry,
+            status
+        );
+        assert_eq!(
+            Items::NONE,
+            active.item,
+            "{:?} should have been consumed",
+            berry
+        );
+    }
+}
+
+#[test]
+fn test_aspearberry_cures_freeze() {
+    assert_status_cure_berry(Items::ASPEARBERRY, PokemonStatus::FREEZE);
+}
+
+#[test]
+fn test_cheriberry_cures_paralysis() {
+    assert_status_cure_berry(Items::CHERIBERRY, PokemonStatus::PARALYZE);
+}
+
+#[test]
+fn test_rawstberry_cures_burn() {
+    assert_status_cure_berry(Items::RAWSTBERRY, PokemonStatus::BURN);
+}
+
+#[test]
+fn test_pechaberry_cures_poison() {
+    assert_status_cure_berry(Items::PECHABERRY, PokemonStatus::POISON);
+}
+
+#[test]
+fn test_pechaberry_cures_toxic() {
+    assert_status_cure_berry(Items::PECHABERRY, PokemonStatus::TOXIC);
+}

--- a/tests/test_gen3.rs
+++ b/tests/test_gen3.rs
@@ -580,3 +580,60 @@ fn test_gen3_branch_when_a_roll_can_kill() {
     ];
     assert_eq!(expected_instructions, vec_of_instructions);
 }
+
+// Status-cure berries in gen 3 fire at END OF TURN (not before-move, unlike gens 4+). For
+// statuses that cannot self-resolve mid-turn (burn/poison/toxic/paralysis) every branch
+// therefore ends with the status cured and the berry consumed. (Freeze/sleep can resolve
+// on their own before end of turn, in which case the berry is correctly NOT consumed, so
+// they are not covered by this simple assertion.)
+fn assert_gen3_status_cure_berry(berry: Items, status: PokemonStatus) {
+    let mut state = State::default();
+    state.side_one.get_active().item = berry;
+    state.side_one.get_active().status = status;
+
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::SPLASH,
+        Choices::SPLASH,
+    );
+
+    assert!(!vec_of_instructions.is_empty());
+    for si in &vec_of_instructions {
+        let mut branch = state.clone();
+        branch.apply_instructions(&si.instruction_list);
+        let active = branch.side_one.get_active_immutable();
+        assert_eq!(
+            PokemonStatus::NONE,
+            active.status,
+            "{:?} should have cured {:?} by end of turn",
+            berry,
+            status
+        );
+        assert_eq!(
+            Items::NONE,
+            active.item,
+            "{:?} should have been consumed",
+            berry
+        );
+    }
+}
+
+#[test]
+fn test_rawstberry_cures_burn() {
+    assert_gen3_status_cure_berry(Items::RAWSTBERRY, PokemonStatus::BURN);
+}
+
+#[test]
+fn test_cheriberry_cures_paralysis() {
+    assert_gen3_status_cure_berry(Items::CHERIBERRY, PokemonStatus::PARALYZE);
+}
+
+#[test]
+fn test_pechaberry_cures_poison() {
+    assert_gen3_status_cure_berry(Items::PECHABERRY, PokemonStatus::POISON);
+}
+
+#[test]
+fn test_pechaberry_cures_toxic() {
+    assert_gen3_status_cure_berry(Items::PECHABERRY, PokemonStatus::TOXIC);
+}


### PR DESCRIPTION
Adds some missing status curing berries in gen 3 and 4+: Aspear, Cheri, Pecha, Rawst, Chesto
  - Handled at the end of turn item use for gen 4+, keeping the current berries approximation. (They currently trigger after status effects which means that status effects incorrectly tick 1 time before being cleared by berries)
  - Handled correctly at the end of turn for gen 3