### PR TITLE
Add Mean Look, Block, and Spider Web trapping

### DIFF
--- a/src/choices.rs
+++ b/src/choices.rs
@@ -1512,6 +1512,10 @@ pub static MOVES: LazyLock<HashMap<Choices, Choice>> = LazyLock::new(|| {
                 reflectable: true,
                 ..Default::default()
             },
+            volatile_status: Some(VolatileStatus {
+                target: MoveTarget::Opponent,
+                volatile_status: PokemonVolatileStatus::TRAPPED,
+            }),
             ..Default::default()
         },
     );
@@ -10265,6 +10269,10 @@ pub static MOVES: LazyLock<HashMap<Choices, Choice>> = LazyLock::new(|| {
                 reflectable: true,
                 ..Default::default()
             },
+            volatile_status: Some(VolatileStatus {
+                target: MoveTarget::Opponent,
+                volatile_status: PokemonVolatileStatus::TRAPPED,
+            }),
             ..Default::default()
         },
     );
@@ -15773,6 +15781,10 @@ pub static MOVES: LazyLock<HashMap<Choices, Choice>> = LazyLock::new(|| {
                 reflectable: true,
                 ..Default::default()
             },
+            volatile_status: Some(VolatileStatus {
+                target: MoveTarget::Opponent,
+                volatile_status: PokemonVolatileStatus::TRAPPED,
+            }),
             ..Default::default()
         },
     );

--- a/src/gen3/generate_instructions.rs
+++ b/src/gen3/generate_instructions.rs
@@ -172,6 +172,22 @@ fn generate_instructions_from_switch(
             .volatile_statuses
             .remove(&PokemonVolatileStatus::PARTIALLYTRAPPED);
     }
+    if opposite_side
+        .volatile_statuses
+        .contains(&PokemonVolatileStatus::TRAPPED)
+    {
+        incoming_instructions
+            .instruction_list
+            .push(Instruction::RemoveVolatileStatus(
+                RemoveVolatileStatusInstruction {
+                    side_ref: switching_side_ref.get_other_side(),
+                    volatile_status: PokemonVolatileStatus::TRAPPED,
+                },
+            ));
+        opposite_side
+            .volatile_statuses
+            .remove(&PokemonVolatileStatus::TRAPPED);
+    }
 
     state.re_enable_disabled_moves(
         &switching_side_ref,

--- a/src/gen3/state.rs
+++ b/src/gen3/state.rs
@@ -183,6 +183,7 @@ define_enum_with_from_str! {
         UNBURDEN,
         UPROAR,
         YAWN,
+        TRAPPED,
     },
     default = NONE
 }
@@ -286,6 +287,12 @@ impl Pokemon {
                 true
             }
             PokemonVolatileStatus::CONFUSION => {
+                if active_volatiles.contains(&PokemonVolatileStatus::SUBSTITUTE) {
+                    return false;
+                }
+                true
+            }
+            PokemonVolatileStatus::TRAPPED => {
                 if active_volatiles.contains(&PokemonVolatileStatus::SUBSTITUTE) {
                     return false;
                 }
@@ -436,6 +443,9 @@ impl Side {
         if self
             .volatile_statuses
             .contains(&PokemonVolatileStatus::PARTIALLYTRAPPED)
+            || self
+                .volatile_statuses
+                .contains(&PokemonVolatileStatus::TRAPPED)
         {
             return true;
         } else if opponent_active.ability == Abilities::SHADOWTAG {

--- a/src/genx/generate_instructions.rs
+++ b/src/genx/generate_instructions.rs
@@ -358,6 +358,22 @@ fn generate_instructions_from_switch(
             .volatile_statuses
             .remove(&PokemonVolatileStatus::PARTIALLYTRAPPED);
     }
+    if opposite_side
+        .volatile_statuses
+        .contains(&PokemonVolatileStatus::TRAPPED)
+    {
+        incoming_instructions
+            .instruction_list
+            .push(Instruction::RemoveVolatileStatus(
+                RemoveVolatileStatusInstruction {
+                    side_ref: switching_side_ref.get_other_side(),
+                    volatile_status: PokemonVolatileStatus::TRAPPED,
+                },
+            ));
+        opposite_side
+            .volatile_statuses
+            .remove(&PokemonVolatileStatus::TRAPPED);
+    }
 
     state.re_enable_disabled_moves(
         &switching_side_ref,

--- a/src/genx/state.rs
+++ b/src/genx/state.rs
@@ -264,6 +264,7 @@ define_enum_with_from_str! {
         UNBURDEN,
         UPROAR,
         YAWN,
+        TRAPPED,
     },
     default = NONE
 }
@@ -725,6 +726,12 @@ impl Pokemon {
                 }
                 true
             }
+            PokemonVolatileStatus::TRAPPED => {
+                if active_volatiles.contains(&PokemonVolatileStatus::SUBSTITUTE) {
+                    return false;
+                }
+                true
+            }
             PokemonVolatileStatus::SUBSTITUTE => self.hp > self.maxhp / 4,
             PokemonVolatileStatus::FLINCH => {
                 if !first_move || [Abilities::INNERFOCUS].contains(&self.ability) {
@@ -1095,6 +1102,9 @@ impl Side {
         } else if self
             .volatile_statuses
             .contains(&PokemonVolatileStatus::PARTIALLYTRAPPED)
+            || self
+                .volatile_statuses
+                .contains(&PokemonVolatileStatus::TRAPPED)
         {
             return true;
         } else if opponent_active.ability == Abilities::SHADOWTAG {

--- a/tests/test_battle_mechanics.rs
+++ b/tests/test_battle_mechanics.rs
@@ -7838,6 +7838,139 @@ fn test_noretreat_traps_pokemon() {
 }
 
 #[test]
+fn test_meanlook_applies_trapped() {
+    let mut state = State::default();
+
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::MEANLOOK,
+        Choices::SPLASH,
+    );
+
+    let expected_instructions = vec![StateInstructions {
+        percentage: 100.0,
+        instruction_list: vec![Instruction::ApplyVolatileStatus(
+            ApplyVolatileStatusInstruction {
+                side_ref: SideReference::SideTwo,
+                volatile_status: PokemonVolatileStatus::TRAPPED,
+            },
+        )],
+    }];
+    assert_eq!(expected_instructions, vec_of_instructions);
+}
+
+#[test]
+fn test_block_applies_trapped() {
+    let mut state = State::default();
+
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::BLOCK,
+        Choices::SPLASH,
+    );
+
+    let expected_instructions = vec![StateInstructions {
+        percentage: 100.0,
+        instruction_list: vec![Instruction::ApplyVolatileStatus(
+            ApplyVolatileStatusInstruction {
+                side_ref: SideReference::SideTwo,
+                volatile_status: PokemonVolatileStatus::TRAPPED,
+            },
+        )],
+    }];
+    assert_eq!(expected_instructions, vec_of_instructions);
+}
+
+#[test]
+fn test_spiderweb_applies_trapped() {
+    let mut state = State::default();
+
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::SPIDERWEB,
+        Choices::SPLASH,
+    );
+
+    let expected_instructions = vec![StateInstructions {
+        percentage: 100.0,
+        instruction_list: vec![Instruction::ApplyVolatileStatus(
+            ApplyVolatileStatusInstruction {
+                side_ref: SideReference::SideTwo,
+                volatile_status: PokemonVolatileStatus::TRAPPED,
+            },
+        )],
+    }];
+    assert_eq!(expected_instructions, vec_of_instructions);
+}
+
+#[test]
+fn test_meanlook_traps_opponent_from_switching() {
+    let mut state = State::default();
+    state
+        .side_two
+        .volatile_statuses
+        .insert(PokemonVolatileStatus::TRAPPED);
+
+    let (_side_one_moves, side_two_moves) = state.get_all_options();
+
+    #[cfg(feature = "terastallization")]
+    assert_eq!(
+        vec![
+            MoveChoice::Move(PokemonMoveIndex::M0),
+            MoveChoice::MoveTera(PokemonMoveIndex::M0),
+            MoveChoice::Move(PokemonMoveIndex::M1),
+            MoveChoice::MoveTera(PokemonMoveIndex::M1),
+            MoveChoice::Move(PokemonMoveIndex::M2),
+            MoveChoice::MoveTera(PokemonMoveIndex::M2),
+            MoveChoice::Move(PokemonMoveIndex::M3),
+            MoveChoice::MoveTera(PokemonMoveIndex::M3),
+        ],
+        side_two_moves
+    );
+    #[cfg(not(feature = "terastallization"))]
+    assert_eq!(
+        vec![
+            MoveChoice::Move(PokemonMoveIndex::M0),
+            MoveChoice::Move(PokemonMoveIndex::M1),
+            MoveChoice::Move(PokemonMoveIndex::M2),
+            MoveChoice::Move(PokemonMoveIndex::M3),
+        ],
+        side_two_moves
+    );
+}
+
+#[test]
+fn test_switching_out_clears_opponent_trapped() {
+    let mut state = State::default();
+    state
+        .side_two
+        .volatile_statuses
+        .insert(PokemonVolatileStatus::TRAPPED);
+
+    let vec_of_instructions = generate_instructions_with_state_assertion(
+        &mut state,
+        &MoveChoice::Switch(PokemonIndex::P1),
+        &MoveChoice::None,
+    );
+
+    let expected_instructions = vec![StateInstructions {
+        percentage: 100.0,
+        instruction_list: vec![
+            Instruction::RemoveVolatileStatus(RemoveVolatileStatusInstruction {
+                side_ref: SideReference::SideTwo,
+                volatile_status: PokemonVolatileStatus::TRAPPED,
+            }),
+            Instruction::Switch(SwitchInstruction {
+                side_ref: SideReference::SideOne,
+                previous_index: PokemonIndex::P0,
+                next_index: PokemonIndex::P1,
+            }),
+        ],
+    }];
+    assert_eq!(expected_instructions, vec_of_instructions);
+}
+
+#[test]
 fn test_meteorbeam_volatile_only_allows_meteor_beam_to_be_used() {
     let mut state = State::default();
     state

--- a/tests/test_gen3.rs
+++ b/tests/test_gen3.rs
@@ -580,3 +580,77 @@ fn test_gen3_branch_when_a_roll_can_kill() {
     ];
     assert_eq!(expected_instructions, vec_of_instructions);
 }
+
+#[test]
+fn test_meanlook_applies_trapped() {
+    let mut state = State::default();
+
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::MEANLOOK,
+        Choices::SPLASH,
+    );
+
+    let expected_instructions = vec![StateInstructions {
+        percentage: 100.0,
+        instruction_list: vec![Instruction::ApplyVolatileStatus(
+            ApplyVolatileStatusInstruction {
+                side_ref: SideReference::SideTwo,
+                volatile_status: PokemonVolatileStatus::TRAPPED,
+            },
+        )],
+    }];
+    assert_eq!(expected_instructions, vec_of_instructions);
+}
+
+#[test]
+fn test_meanlook_traps_opponent_from_switching() {
+    let mut state = State::default();
+    state
+        .side_two
+        .volatile_statuses
+        .insert(PokemonVolatileStatus::TRAPPED);
+
+    let (_side_one_moves, side_two_moves) = state.get_all_options();
+
+    assert_eq!(
+        vec![
+            MoveChoice::Move(PokemonMoveIndex::M0),
+            MoveChoice::Move(PokemonMoveIndex::M1),
+            MoveChoice::Move(PokemonMoveIndex::M2),
+            MoveChoice::Move(PokemonMoveIndex::M3),
+        ],
+        side_two_moves
+    );
+}
+
+#[test]
+fn test_switching_out_clears_opponent_trapped() {
+    let mut state = State::default();
+    state
+        .side_two
+        .volatile_statuses
+        .insert(PokemonVolatileStatus::TRAPPED);
+
+    let vec_of_instructions = generate_instructions_with_state_assertion(
+        &mut state,
+        &MoveChoice::Switch(PokemonIndex::P1),
+        &MoveChoice::None,
+    );
+
+    let expected_instructions = vec![StateInstructions {
+        percentage: 100.0,
+        instruction_list: vec![
+            Instruction::RemoveVolatileStatus(RemoveVolatileStatusInstruction {
+                side_ref: SideReference::SideTwo,
+                volatile_status: PokemonVolatileStatus::TRAPPED,
+            }),
+            Instruction::Switch(SwitchInstruction {
+                side_ref: SideReference::SideOne,
+                previous_index: PokemonIndex::P0,
+                next_index: PokemonIndex::P1,
+            }),
+        ],
+    }];
+    assert_eq!(expected_instructions, vec_of_instructions);
+}


### PR DESCRIPTION
- Apply a shared `TRAPPED` volatile for Mean Look, Block, and Spider Web
- Block switching while trapped, and clear the foe's trap when the trapper switches out
- Cover gen3 and genx