### PR TITLE
Implement Electric / Grassy / Psychic / Misty Terrain move effects in genx

### DIFF
--- a/src/genx/choice_effects.rs
+++ b/src/genx/choice_effects.rs
@@ -1743,6 +1743,62 @@ pub fn choice_special_effect(
                 state.weather.turns_remaining = 5;
             }
         }
+        Choices::ELECTRICTERRAIN => {
+            if state.terrain.terrain_type != Terrain::ELECTRICTERRAIN {
+                instructions
+                    .instruction_list
+                    .push(Instruction::ChangeTerrain(ChangeTerrain {
+                        new_terrain: Terrain::ELECTRICTERRAIN,
+                        new_terrain_turns_remaining: 5,
+                        previous_terrain: state.terrain.terrain_type,
+                        previous_terrain_turns_remaining: state.terrain.turns_remaining,
+                    }));
+                state.terrain.terrain_type = Terrain::ELECTRICTERRAIN;
+                state.terrain.turns_remaining = 5;
+            }
+        }
+        Choices::GRASSYTERRAIN => {
+            if state.terrain.terrain_type != Terrain::GRASSYTERRAIN {
+                instructions
+                    .instruction_list
+                    .push(Instruction::ChangeTerrain(ChangeTerrain {
+                        new_terrain: Terrain::GRASSYTERRAIN,
+                        new_terrain_turns_remaining: 5,
+                        previous_terrain: state.terrain.terrain_type,
+                        previous_terrain_turns_remaining: state.terrain.turns_remaining,
+                    }));
+                state.terrain.terrain_type = Terrain::GRASSYTERRAIN;
+                state.terrain.turns_remaining = 5;
+            }
+        }
+        Choices::PSYCHICTERRAIN => {
+            if state.terrain.terrain_type != Terrain::PSYCHICTERRAIN {
+                instructions
+                    .instruction_list
+                    .push(Instruction::ChangeTerrain(ChangeTerrain {
+                        new_terrain: Terrain::PSYCHICTERRAIN,
+                        new_terrain_turns_remaining: 5,
+                        previous_terrain: state.terrain.terrain_type,
+                        previous_terrain_turns_remaining: state.terrain.turns_remaining,
+                    }));
+                state.terrain.terrain_type = Terrain::PSYCHICTERRAIN;
+                state.terrain.turns_remaining = 5;
+            }
+        }
+        Choices::MISTYTERRAIN => {
+            if state.terrain.terrain_type != Terrain::MISTYTERRAIN {
+                instructions
+                    .instruction_list
+                    .push(Instruction::ChangeTerrain(ChangeTerrain {
+                        new_terrain: Terrain::MISTYTERRAIN,
+                        new_terrain_turns_remaining: 5,
+                        previous_terrain: state.terrain.terrain_type,
+                        previous_terrain_turns_remaining: state.terrain.turns_remaining,
+                    }));
+                state.terrain.terrain_type = Terrain::MISTYTERRAIN;
+                state.terrain.turns_remaining = 5;
+            }
+        }
         _ => {}
     }
 }

--- a/src/genx/generate_instructions.rs
+++ b/src/genx/generate_instructions.rs
@@ -6427,6 +6427,165 @@ mod tests {
     }
 
     #[test]
+    fn test_electric_terrain_sets_terrain() {
+        let mut state: State = State::default();
+        let mut choice = MOVES
+            .get(&Choices::ELECTRICTERRAIN)
+            .unwrap()
+            .to_owned();
+
+        let mut instructions = vec![];
+        generate_instructions_from_move(
+            &mut state,
+            &mut choice,
+            &MOVES.get(&Choices::TACKLE).unwrap(),
+            SideReference::SideOne,
+            StateInstructions::default(),
+            &mut instructions,
+            false,
+        );
+
+        let expected_instructions = vec![StateInstructions {
+            percentage: 100.0,
+            instruction_list: vec![Instruction::ChangeTerrain(ChangeTerrain {
+                new_terrain: Terrain::ELECTRICTERRAIN,
+                new_terrain_turns_remaining: 5,
+                previous_terrain: Terrain::NONE,
+                previous_terrain_turns_remaining: 0,
+            })],
+        }];
+
+        assert_eq!(instructions, expected_instructions)
+    }
+
+    #[test]
+    fn test_electric_terrain_fails_if_already_active() {
+        let mut state: State = State::default();
+        state.terrain.terrain_type = Terrain::ELECTRICTERRAIN;
+        state.terrain.turns_remaining = 3;
+        let mut choice = MOVES
+            .get(&Choices::ELECTRICTERRAIN)
+            .unwrap()
+            .to_owned();
+
+        let mut instructions = vec![];
+        generate_instructions_from_move(
+            &mut state,
+            &mut choice,
+            &MOVES.get(&Choices::TACKLE).unwrap(),
+            SideReference::SideOne,
+            StateInstructions::default(),
+            &mut instructions,
+            false,
+        );
+
+        let expected_instructions = vec![StateInstructions {
+            percentage: 100.0,
+            instruction_list: vec![],
+        }];
+
+        assert_eq!(instructions, expected_instructions)
+    }
+
+    #[test]
+    fn test_grassy_terrain_replaces_other_terrain() {
+        let mut state: State = State::default();
+        state.terrain.terrain_type = Terrain::ELECTRICTERRAIN;
+        state.terrain.turns_remaining = 2;
+        let mut choice = MOVES
+            .get(&Choices::GRASSYTERRAIN)
+            .unwrap()
+            .to_owned();
+
+        let mut instructions = vec![];
+        generate_instructions_from_move(
+            &mut state,
+            &mut choice,
+            &MOVES.get(&Choices::TACKLE).unwrap(),
+            SideReference::SideOne,
+            StateInstructions::default(),
+            &mut instructions,
+            false,
+        );
+
+        let expected_instructions = vec![StateInstructions {
+            percentage: 100.0,
+            instruction_list: vec![Instruction::ChangeTerrain(ChangeTerrain {
+                new_terrain: Terrain::GRASSYTERRAIN,
+                new_terrain_turns_remaining: 5,
+                previous_terrain: Terrain::ELECTRICTERRAIN,
+                previous_terrain_turns_remaining: 2,
+            })],
+        }];
+
+        assert_eq!(instructions, expected_instructions)
+    }
+
+    #[test]
+    fn test_psychic_terrain_sets_terrain() {
+        let mut state: State = State::default();
+        let mut choice = MOVES
+            .get(&Choices::PSYCHICTERRAIN)
+            .unwrap()
+            .to_owned();
+
+        let mut instructions = vec![];
+        generate_instructions_from_move(
+            &mut state,
+            &mut choice,
+            &MOVES.get(&Choices::TACKLE).unwrap(),
+            SideReference::SideOne,
+            StateInstructions::default(),
+            &mut instructions,
+            false,
+        );
+
+        let expected_instructions = vec![StateInstructions {
+            percentage: 100.0,
+            instruction_list: vec![Instruction::ChangeTerrain(ChangeTerrain {
+                new_terrain: Terrain::PSYCHICTERRAIN,
+                new_terrain_turns_remaining: 5,
+                previous_terrain: Terrain::NONE,
+                previous_terrain_turns_remaining: 0,
+            })],
+        }];
+
+        assert_eq!(instructions, expected_instructions)
+    }
+
+    #[test]
+    fn test_misty_terrain_sets_terrain() {
+        let mut state: State = State::default();
+        let mut choice = MOVES
+            .get(&Choices::MISTYTERRAIN)
+            .unwrap()
+            .to_owned();
+
+        let mut instructions = vec![];
+        generate_instructions_from_move(
+            &mut state,
+            &mut choice,
+            &MOVES.get(&Choices::TACKLE).unwrap(),
+            SideReference::SideOne,
+            StateInstructions::default(),
+            &mut instructions,
+            false,
+        );
+
+        let expected_instructions = vec![StateInstructions {
+            percentage: 100.0,
+            instruction_list: vec![Instruction::ChangeTerrain(ChangeTerrain {
+                new_terrain: Terrain::MISTYTERRAIN,
+                new_terrain_turns_remaining: 5,
+                previous_terrain: Terrain::NONE,
+                previous_terrain_turns_remaining: 0,
+            })],
+        }];
+
+        assert_eq!(instructions, expected_instructions)
+    }
+
+    #[test]
     fn test_tidyup_clears_side_conditions_and_substitutes() {
         let mut state: State = State::default();
         state.terrain.terrain_type = Terrain::ELECTRICTERRAIN;


### PR DESCRIPTION
Implement Electric Terrain, Grassy Terrain, Psychic Terrain, and Misty Terrain moves