### PR TITLE
Fix Doom Desire move

### DIFF
--- a/poke-engine-py/python/poke_engine/poke_engine.pyi
+++ b/poke-engine-py/python/poke_engine/poke_engine.pyi
@@ -278,8 +278,8 @@ class Side:
     :type volatile_status_durations: VolatileStatusDurations
     :param wish: Wish status (turns, HP)
     :type wish: tuple[int, int]
-    :param future_sight: Future Sight status (turns, target)
-    :type future_sight: tuple[int, str]
+    :param future_attack: Future Sight / Doom Desire status (turns, pokemon index, move id)
+    :type future_attack: tuple[int, str, str]
     :param force_switch: Whether forced to switch
     :type force_switch: bool
     :param force_trapped: Whether trapped
@@ -317,7 +317,7 @@ class Side:
     shed_tailing: bool
     volatile_status_durations: VolatileStatusDurations
     wish: Tuple[int, int]
-    future_sight: Tuple[int, str]
+    future_attack: Tuple[int, str, str]
     force_switch: bool
     force_trapped: bool
     slow_uturn_move: bool
@@ -341,7 +341,7 @@ class Side:
         shed_tailing: bool = False,
         volatile_status_durations: Optional[VolatileStatusDurations] = None,
         wish: Tuple[int, int] = (0, 0),
-        future_sight: Tuple[int, str] = (0, "0"),
+        future_attack: Tuple[int, str, str] = (0, "0", "none"),
         force_switch: bool = False,
         force_trapped: bool = False,
         slow_uturn_move: bool = False,

--- a/poke-engine-py/src/lib.rs
+++ b/poke-engine-py/src/lib.rs
@@ -16,9 +16,9 @@ use poke_engine::mcts_threaded::perform_mcts_shared_tree;
 use poke_engine::pokemon::PokemonName;
 use poke_engine::search::iterative_deepen_expectiminimax;
 use poke_engine::state::{
-    LastUsedMove, Move, Pokemon, PokemonIndex, PokemonMoves, PokemonNature, PokemonStatus,
-    PokemonType, Side, SideConditions, SidePokemon, State, StateTerrain, StateTrickRoom,
-    StateWeather, VolatileStatusBitset, VolatileStatusDurations,
+    FutureAttack, LastUsedMove, Move, Pokemon, PokemonIndex, PokemonMoves, PokemonNature,
+    PokemonStatus, PokemonType, Side, SideConditions, SidePokemon, State, StateTerrain,
+    StateTrickRoom, StateWeather, VolatileStatusBitset, VolatileStatusDurations,
 };
 use std::str::FromStr;
 use std::time::Duration;
@@ -159,7 +159,7 @@ pub struct PySide {
     shed_tailing: bool,
     volatile_status_durations: PyVolatileStatusDurations,
     wish: (i8, i16),
-    future_sight: (i8, String),
+    future_attack: (i8, String, String),
     force_switch: bool,
     force_trapped: bool,
     slow_uturn_move: bool,
@@ -197,7 +197,11 @@ impl From<Side> for PySide {
                 other.volatile_status_durations,
             ),
             wish: other.wish,
-            future_sight: (other.future_sight.0, other.future_sight.1.serialize()),
+            future_attack: (
+                other.future_attack.turns_remaining,
+                other.future_attack.pokemon_index.serialize(),
+                other.future_attack.move_id.to_string(),
+            ),
             force_switch: other.force_switch,
             force_trapped: other.force_trapped,
             slow_uturn_move: other.slow_uturn_move,
@@ -243,10 +247,11 @@ impl Into<Side> for PySide {
                 self.volatile_status_durations.into(),
             ),
             wish: self.wish,
-            future_sight: (
-                self.future_sight.0,
-                PokemonIndex::deserialize(&self.future_sight.1),
-            ),
+            future_attack: FutureAttack {
+                turns_remaining: self.future_attack.0,
+                pokemon_index: PokemonIndex::deserialize(&self.future_attack.1),
+                move_id: Choices::from_str(&self.future_attack.2).unwrap_or(Choices::NONE),
+            },
             force_switch: self.force_switch,
             force_trapped: self.force_trapped,
             slow_uturn_move: self.slow_uturn_move,
@@ -280,7 +285,7 @@ impl PySide {
         shed_tailing=false,
         volatile_status_durations=PyVolatileStatusDurations::new(0, 0, 0, 0, 0, 0),
         wish=(0, 0),
-        future_sight=(0, "0".to_string()),
+        future_attack=(0, "0".to_string(), "none".to_string()),
         force_switch=false,
         force_trapped=false,
         slow_uturn_move=false,
@@ -305,7 +310,7 @@ impl PySide {
         shed_tailing: bool,
         volatile_status_durations: PyVolatileStatusDurations,
         wish: (i8, i16),
-        future_sight: (i8, String),
+        future_attack: (i8, String, String),
         force_switch: bool,
         force_trapped: bool,
         slow_uturn_move: bool,
@@ -339,7 +344,7 @@ impl PySide {
             shed_tailing,
             volatile_status_durations,
             wish,
-            future_sight,
+            future_attack,
             force_switch,
             force_trapped,
             slow_uturn_move,

--- a/src/gen2/choice_effects.rs
+++ b/src/gen2/choice_effects.rs
@@ -6,13 +6,13 @@ use crate::choices::{Choice, Choices, Heal, MoveCategory, MoveTarget};
 use crate::instruction::{
     ApplyVolatileStatusInstruction, BoostInstruction, ChangeItemInstruction,
     ChangeSideConditionInstruction, ChangeStatusInstruction, ChangeSubsituteHealthInstruction,
-    ChangeWeather, DamageInstruction, HealInstruction, Instruction,
-    RemoveVolatileStatusInstruction, SetFutureSightInstruction, SetSleepTurnsInstruction,
+    ChangeWeather, DamageInstruction, FutureAttackKind, HealInstruction, Instruction,
+    RemoveVolatileStatusInstruction, SetFutureAttackInstruction, SetSleepTurnsInstruction,
     StateInstructions,
 };
 use crate::state::{
-    pokemon_index_iter, PokemonBoostableStat, PokemonSideCondition, PokemonStatus, PokemonType,
-    Side, SideReference, State,
+    pokemon_index_iter, FutureAttack, PokemonBoostableStat, PokemonSideCondition, PokemonStatus,
+    PokemonType, Side, SideReference, State,
 };
 use std::cmp;
 
@@ -189,16 +189,25 @@ pub fn choice_before_move(
 
     match choice.move_id {
         Choices::FUTURESIGHT => {
+            let move_id = choice.move_id;
             choice.remove_all_effects();
-            if attacking_side.future_sight.0 == 0 {
+            if attacking_side.future_attack.turns_remaining == 0 {
                 instructions
                     .instruction_list
-                    .push(Instruction::SetFutureSight(SetFutureSightInstruction {
+                    .push(Instruction::SetFutureAttack(SetFutureAttackInstruction {
                         side_ref: *attacking_side_ref,
                         pokemon_index: attacking_side.active_index,
-                        previous_pokemon_index: attacking_side.future_sight.1,
+                        previous_pokemon_index: attacking_side.future_attack.pokemon_index,
+                        move_id: FutureAttackKind::from(move_id),
+                        previous_move_id: FutureAttackKind::from(
+                            attacking_side.future_attack.move_id,
+                        ),
                     }));
-                attacking_side.future_sight = (3, attacking_side.active_index);
+                attacking_side.future_attack = FutureAttack {
+                    turns_remaining: 3,
+                    pokemon_index: attacking_side.active_index,
+                    move_id,
+                };
             }
         }
         Choices::EXPLOSION | Choices::SELFDESTRUCT => {

--- a/src/gen2/damage_calc.rs
+++ b/src/gen2/damage_calc.rs
@@ -283,7 +283,7 @@ pub fn calculate_damage(
     Some((damage as i16, crit_damage as i16))
 }
 
-pub fn calculate_futuresight_damage(
+pub fn calculate_future_attack_damage(
     attacking_side: &Side,
     defending_side: &Side,
     attacking_side_pokemon_index: &PokemonIndex,
@@ -291,6 +291,10 @@ pub fn calculate_futuresight_damage(
     let attacking_stat = attacking_side.pokemon[attacking_side_pokemon_index].special_attack;
     let defending_stat = defending_side.get_active_immutable().special_defense;
     let attacker = attacking_side.get_active_immutable();
+    let move_id = match attacking_side.future_attack.move_id {
+        Choices::NONE => Choices::FUTURESIGHT,
+        m => m,
+    };
     let damage = common_pkmn_damage_calc(
         attacker,
         attacking_stat,
@@ -298,7 +302,7 @@ pub fn calculate_futuresight_damage(
         defending_side.get_active_immutable(),
         defending_stat,
         &Weather::NONE,
-        MOVES.get(&Choices::FUTURESIGHT).unwrap(),
+        MOVES.get(&move_id).unwrap(),
     );
 
     (damage * 0.925) as i16

--- a/src/gen2/damage_calc.rs
+++ b/src/gen2/damage_calc.rs
@@ -1,6 +1,6 @@
 use super::state::{PokemonVolatileStatus, Weather};
 use crate::choices::{Choice, MoveCategory};
-use crate::choices::{Choices, MOVES};
+use crate::choices::MOVES;
 use crate::state::{
     Pokemon, PokemonBoostableStat, PokemonIndex, PokemonStatus, PokemonType, Side, SideReference,
     State,
@@ -291,10 +291,6 @@ pub fn calculate_future_attack_damage(
     let attacking_stat = attacking_side.pokemon[attacking_side_pokemon_index].special_attack;
     let defending_stat = defending_side.get_active_immutable().special_defense;
     let attacker = attacking_side.get_active_immutable();
-    let move_id = match attacking_side.future_attack.move_id {
-        Choices::NONE => Choices::FUTURESIGHT,
-        m => m,
-    };
     let damage = common_pkmn_damage_calc(
         attacker,
         attacking_stat,
@@ -302,7 +298,7 @@ pub fn calculate_future_attack_damage(
         defending_side.get_active_immutable(),
         defending_stat,
         &Weather::NONE,
-        MOVES.get(&move_id).unwrap(),
+        MOVES.get(&attacking_side.future_attack.move_id).unwrap(),
     );
 
     (damage * 0.925) as i16

--- a/src/gen2/generate_instructions.rs
+++ b/src/gen2/generate_instructions.rs
@@ -6,7 +6,7 @@ use crate::choices::{
     Boost, Choices, Effect, Heal, MoveTarget, MultiHitMove, Secondary, SideCondition, Status,
     VolatileStatus, MOVES,
 };
-use crate::instruction::DecrementFutureSightInstruction;
+use crate::instruction::DecrementFutureAttackInstruction;
 use crate::instruction::{
     ApplyVolatileStatusInstruction, BoostInstruction, ChangeItemInstruction,
     ChangeSideConditionInstruction, ChangeWeather, DecrementRestTurnsInstruction, HealInstruction,
@@ -19,7 +19,7 @@ use crate::instruction::{
 };
 use crate::instruction::{DecrementPPInstruction, SetLastUsedMoveInstruction};
 
-use super::damage_calc::calculate_futuresight_damage;
+use super::damage_calc::calculate_future_attack_damage;
 use super::damage_calc::{calculate_damage, type_effectiveness_modifier, DamageRolls};
 use super::items::{
     item_before_move, item_end_of_turn, item_modify_attack_against, item_modify_attack_being_used,
@@ -1788,32 +1788,32 @@ pub fn add_end_of_turn_instructions(
     // future sight
     for side_ref in sides {
         let (attacking_side, defending_side) = state.get_both_sides(side_ref);
-        if attacking_side.future_sight.0 > 0 {
-            let decrement_future_sight_instruction =
-                Instruction::DecrementFutureSight(DecrementFutureSightInstruction {
+        if attacking_side.future_attack.turns_remaining > 0 {
+            let decrement_future_attack_instruction =
+                Instruction::DecrementFutureAttack(DecrementFutureAttackInstruction {
                     side_ref: *side_ref,
                 });
-            if attacking_side.future_sight.0 == 1 {
-                let mut damage = calculate_futuresight_damage(
+            if attacking_side.future_attack.turns_remaining == 1 {
+                let mut damage = calculate_future_attack_damage(
                     &attacking_side,
                     &defending_side,
-                    &attacking_side.future_sight.1,
+                    &attacking_side.future_attack.pokemon_index,
                 );
                 let defender = defending_side.get_active();
                 damage = cmp::min(damage, defender.hp);
-                let future_sight_damage_instruction = Instruction::Damage(DamageInstruction {
+                let future_attack_damage_instruction = Instruction::Damage(DamageInstruction {
                     side_ref: side_ref.get_other_side(),
                     damage_amount: damage,
                 });
                 incoming_instructions
                     .instruction_list
-                    .push(future_sight_damage_instruction);
+                    .push(future_attack_damage_instruction);
                 defender.hp -= damage;
             }
-            attacking_side.future_sight.0 -= 1;
+            attacking_side.future_attack.turns_remaining -= 1;
             incoming_instructions
                 .instruction_list
-                .push(decrement_future_sight_instruction);
+                .push(decrement_future_attack_instruction);
         }
     }
 

--- a/src/gen3/choice_effects.rs
+++ b/src/gen3/choice_effects.rs
@@ -7,13 +7,13 @@ use crate::choices::{Boost, Choice, Choices, Heal, MoveCategory, MoveTarget, Sta
 use crate::instruction::{
     ApplyVolatileStatusInstruction, BoostInstruction, ChangeItemInstruction,
     ChangeSideConditionInstruction, ChangeStatusInstruction, ChangeSubsituteHealthInstruction,
-    ChangeWeather, ChangeWishInstruction, DamageInstruction, HealInstruction, Instruction,
-    RemoveVolatileStatusInstruction, SetFutureSightInstruction, SetSleepTurnsInstruction,
-    StateInstructions,
+    ChangeWeather, ChangeWishInstruction, DamageInstruction, FutureAttackKind, HealInstruction,
+    Instruction, RemoveVolatileStatusInstruction, SetFutureAttackInstruction,
+    SetSleepTurnsInstruction, StateInstructions,
 };
 use crate::state::{
-    pokemon_index_iter, LastUsedMove, PokemonBoostableStat, PokemonSideCondition, PokemonStatus,
-    PokemonType, Side, SideReference, State,
+    pokemon_index_iter, FutureAttack, LastUsedMove, PokemonBoostableStat, PokemonSideCondition,
+    PokemonStatus, PokemonType, Side, SideReference, State,
 };
 use std::cmp;
 
@@ -291,17 +291,26 @@ pub fn choice_before_move(
     let defender = defending_side.get_active_immutable();
 
     match choice.move_id {
-        Choices::FUTURESIGHT => {
+        Choices::FUTURESIGHT | Choices::DOOMDESIRE => {
+            let move_id = choice.move_id;
             choice.remove_all_effects();
-            if attacking_side.future_sight.0 == 0 {
+            if attacking_side.future_attack.turns_remaining == 0 {
                 instructions
                     .instruction_list
-                    .push(Instruction::SetFutureSight(SetFutureSightInstruction {
+                    .push(Instruction::SetFutureAttack(SetFutureAttackInstruction {
                         side_ref: *attacking_side_ref,
                         pokemon_index: attacking_side.active_index,
-                        previous_pokemon_index: attacking_side.future_sight.1,
+                        previous_pokemon_index: attacking_side.future_attack.pokemon_index,
+                        move_id: FutureAttackKind::from(move_id),
+                        previous_move_id: FutureAttackKind::from(
+                            attacking_side.future_attack.move_id,
+                        ),
                     }));
-                attacking_side.future_sight = (3, attacking_side.active_index);
+                attacking_side.future_attack = FutureAttack {
+                    turns_remaining: 3,
+                    pokemon_index: attacking_side.active_index,
+                    move_id,
+                };
             }
         }
         Choices::EXPLOSION | Choices::SELFDESTRUCT if defender.ability != Abilities::DAMP => {

--- a/src/gen3/damage_calc.rs
+++ b/src/gen3/damage_calc.rs
@@ -332,7 +332,7 @@ pub fn calculate_damage(
     Some((damage as i16, crit_damage as i16))
 }
 
-pub fn calculate_futuresight_damage(
+pub fn calculate_future_attack_damage(
     attacking_side: &Side,
     defending_side: &Side,
     attacking_side_pokemon_index: &PokemonIndex,
@@ -340,6 +340,10 @@ pub fn calculate_futuresight_damage(
     let attacking_stat = attacking_side.pokemon[attacking_side_pokemon_index].special_attack;
     let defending_stat = defending_side.get_active_immutable().special_defense;
     let attacker = attacking_side.get_active_immutable();
+    let move_id = match attacking_side.future_attack.move_id {
+        Choices::NONE => Choices::FUTURESIGHT,
+        m => m,
+    };
     let mut damage = common_pkmn_damage_calc(
         attacking_side,
         attacker,
@@ -348,7 +352,7 @@ pub fn calculate_futuresight_damage(
         defending_side.get_active_immutable(),
         defending_stat,
         &Weather::NONE,
-        MOVES.get(&Choices::FUTURESIGHT).unwrap(),
+        MOVES.get(&move_id).unwrap(),
     );
     if defending_side.side_conditions.light_screen > 0 {
         damage *= 0.5

--- a/src/gen3/damage_calc.rs
+++ b/src/gen3/damage_calc.rs
@@ -1,7 +1,7 @@
 use super::abilities::Abilities;
 use super::state::{PokemonVolatileStatus, Weather};
 use crate::choices::{Choice, MoveCategory};
-use crate::choices::{Choices, MOVES};
+use crate::choices::MOVES;
 use crate::state::{
     Pokemon, PokemonBoostableStat, PokemonIndex, PokemonStatus, PokemonType, Side, SideReference,
     State,
@@ -340,10 +340,6 @@ pub fn calculate_future_attack_damage(
     let attacking_stat = attacking_side.pokemon[attacking_side_pokemon_index].special_attack;
     let defending_stat = defending_side.get_active_immutable().special_defense;
     let attacker = attacking_side.get_active_immutable();
-    let move_id = match attacking_side.future_attack.move_id {
-        Choices::NONE => Choices::FUTURESIGHT,
-        m => m,
-    };
     let mut damage = common_pkmn_damage_calc(
         attacking_side,
         attacker,
@@ -352,7 +348,7 @@ pub fn calculate_future_attack_damage(
         defending_side.get_active_immutable(),
         defending_stat,
         &Weather::NONE,
-        MOVES.get(&move_id).unwrap(),
+        MOVES.get(&attacking_side.future_attack.move_id).unwrap(),
     );
     if defending_side.side_conditions.light_screen > 0 {
         damage *= 0.5

--- a/src/gen3/generate_instructions.rs
+++ b/src/gen3/generate_instructions.rs
@@ -10,7 +10,7 @@ use crate::choices::{
     Boost, Choices, Effect, Heal, MoveTarget, MultiHitMove, Secondary, SideCondition, Status,
     VolatileStatus, MOVES,
 };
-use crate::instruction::DecrementFutureSightInstruction;
+use crate::instruction::DecrementFutureAttackInstruction;
 use crate::instruction::{
     ApplyVolatileStatusInstruction, BoostInstruction, ChangeDamageDealtDamageInstruction,
     ChangeDamageDealtMoveCategoryInstruction, ChangeItemInstruction,
@@ -22,7 +22,7 @@ use crate::instruction::{
 };
 use crate::instruction::{DecrementPPInstruction, SetLastUsedMoveInstruction};
 
-use super::damage_calc::calculate_futuresight_damage;
+use super::damage_calc::calculate_future_attack_damage;
 use super::damage_calc::{calculate_damage, type_effectiveness_modifier, DamageRolls};
 use super::items::{
     item_before_move, item_end_of_turn, item_modify_attack_against, item_modify_attack_being_used,
@@ -2037,32 +2037,32 @@ fn add_end_of_turn_instructions(
     // future sight
     for side_ref in sides {
         let (attacking_side, defending_side) = state.get_both_sides(side_ref);
-        if attacking_side.future_sight.0 > 0 {
-            let decrement_future_sight_instruction =
-                Instruction::DecrementFutureSight(DecrementFutureSightInstruction {
+        if attacking_side.future_attack.turns_remaining > 0 {
+            let decrement_future_attack_instruction =
+                Instruction::DecrementFutureAttack(DecrementFutureAttackInstruction {
                     side_ref: *side_ref,
                 });
-            if attacking_side.future_sight.0 == 1 {
-                let mut damage = calculate_futuresight_damage(
+            if attacking_side.future_attack.turns_remaining == 1 {
+                let mut damage = calculate_future_attack_damage(
                     &attacking_side,
                     &defending_side,
-                    &attacking_side.future_sight.1,
+                    &attacking_side.future_attack.pokemon_index,
                 );
                 let defender = defending_side.get_active();
                 damage = cmp::min(damage, defender.hp);
-                let future_sight_damage_instruction = Instruction::Damage(DamageInstruction {
+                let future_attack_damage_instruction = Instruction::Damage(DamageInstruction {
                     side_ref: side_ref.get_other_side(),
                     damage_amount: damage,
                 });
                 incoming_instructions
                     .instruction_list
-                    .push(future_sight_damage_instruction);
+                    .push(future_attack_damage_instruction);
                 defender.hp -= damage;
             }
-            attacking_side.future_sight.0 -= 1;
+            attacking_side.future_attack.turns_remaining -= 1;
             incoming_instructions
                 .instruction_list
-                .push(decrement_future_sight_instruction);
+                .push(decrement_future_attack_instruction);
         }
     }
 
@@ -3004,8 +3004,8 @@ pub fn calculate_damage_rolls(
         &mut incoming_instructions,
     );
 
-    if choice.move_id == Choices::FUTURESIGHT {
-        choice = MOVES.get(&Choices::FUTURESIGHT)?.clone();
+    if choice.move_id == Choices::FUTURESIGHT || choice.move_id == Choices::DOOMDESIRE {
+        choice = MOVES.get(&choice.move_id)?.clone();
     }
 
     let mut return_vec = Vec::with_capacity(4);

--- a/src/genx/choice_effects.rs
+++ b/src/genx/choice_effects.rs
@@ -10,13 +10,14 @@ use crate::instruction::{
     ApplyVolatileStatusInstruction, BoostInstruction, ChangeItemInstruction,
     ChangeSideConditionInstruction, ChangeStatusInstruction, ChangeSubsituteHealthInstruction,
     ChangeTerrain, ChangeType, ChangeWeather, ChangeWishInstruction, DamageInstruction,
-    HealInstruction, Instruction, RemoveVolatileStatusInstruction, SetFutureSightInstruction,
-    SetSleepTurnsInstruction, StateInstructions, ToggleTrickRoomInstruction,
+    FutureAttackKind, HealInstruction, Instruction, RemoveVolatileStatusInstruction,
+    SetFutureAttackInstruction, SetSleepTurnsInstruction, StateInstructions,
+    ToggleTrickRoomInstruction,
 };
 use crate::pokemon::PokemonName;
 use crate::state::{
-    pokemon_index_iter, LastUsedMove, PokemonBoostableStat, PokemonSideCondition, PokemonStatus,
-    PokemonType, Side, SideReference, State,
+    pokemon_index_iter, FutureAttack, LastUsedMove, PokemonBoostableStat, PokemonSideCondition,
+    PokemonStatus, PokemonType, Side, SideReference, State,
 };
 use std::cmp;
 
@@ -958,17 +959,26 @@ pub fn choice_before_move(
     let defender = defending_side.get_active_immutable();
 
     match choice.move_id {
-        Choices::FUTURESIGHT => {
+        Choices::FUTURESIGHT | Choices::DOOMDESIRE => {
+            let move_id = choice.move_id;
             choice.remove_all_effects();
-            if attacking_side.future_sight.0 == 0 {
+            if attacking_side.future_attack.turns_remaining == 0 {
                 instructions
                     .instruction_list
-                    .push(Instruction::SetFutureSight(SetFutureSightInstruction {
+                    .push(Instruction::SetFutureAttack(SetFutureAttackInstruction {
                         side_ref: *attacking_side_ref,
                         pokemon_index: attacking_side.active_index,
-                        previous_pokemon_index: attacking_side.future_sight.1,
+                        previous_pokemon_index: attacking_side.future_attack.pokemon_index,
+                        move_id: FutureAttackKind::from(move_id),
+                        previous_move_id: FutureAttackKind::from(
+                            attacking_side.future_attack.move_id,
+                        ),
                     }));
-                attacking_side.future_sight = (3, attacking_side.active_index);
+                attacking_side.future_attack = FutureAttack {
+                    turns_remaining: 3,
+                    pokemon_index: attacking_side.active_index,
+                    move_id,
+                };
             }
         }
         Choices::EXPLOSION | Choices::SELFDESTRUCT | Choices::MISTYEXPLOSION

--- a/src/genx/damage_calc.rs
+++ b/src/genx/damage_calc.rs
@@ -656,10 +656,6 @@ pub fn calculate_future_attack_damage(
     let attacking_stat = attacking_side.pokemon[attacking_side_pokemon_index].special_attack;
     let defending_stat = defending_side.get_active_immutable().special_defense;
     let attacker = attacking_side.get_active_immutable();
-    let move_id = match attacking_side.future_attack.move_id {
-        Choices::NONE => Choices::FUTURESIGHT,
-        m => m,
-    };
     let (mut damage, _) = common_pkmn_damage_calc(
         attacking_side,
         attacker,
@@ -671,7 +667,7 @@ pub fn calculate_future_attack_damage(
         defending_stat,
         &Weather::NONE,
         &Terrain::NONE,
-        MOVES.get(&move_id).unwrap(),
+        MOVES.get(&attacking_side.future_attack.move_id).unwrap(),
     );
     if attacker.ability != Abilities::INFILTRATOR {
         if defending_side.side_conditions.light_screen > 0 {

--- a/src/genx/damage_calc.rs
+++ b/src/genx/damage_calc.rs
@@ -648,7 +648,7 @@ pub fn calculate_damage(
     Some((damage as i16, crit_damage as i16))
 }
 
-pub fn calculate_futuresight_damage(
+pub fn calculate_future_attack_damage(
     attacking_side: &Side,
     defending_side: &Side,
     attacking_side_pokemon_index: &PokemonIndex,
@@ -656,6 +656,10 @@ pub fn calculate_futuresight_damage(
     let attacking_stat = attacking_side.pokemon[attacking_side_pokemon_index].special_attack;
     let defending_stat = defending_side.get_active_immutable().special_defense;
     let attacker = attacking_side.get_active_immutable();
+    let move_id = match attacking_side.future_attack.move_id {
+        Choices::NONE => Choices::FUTURESIGHT,
+        m => m,
+    };
     let (mut damage, _) = common_pkmn_damage_calc(
         attacking_side,
         attacker,
@@ -667,7 +671,7 @@ pub fn calculate_futuresight_damage(
         defending_stat,
         &Weather::NONE,
         &Terrain::NONE,
-        MOVES.get(&Choices::FUTURESIGHT).unwrap(),
+        MOVES.get(&move_id).unwrap(),
     );
     if attacker.ability != Abilities::INFILTRATOR {
         if defending_side.side_conditions.light_screen > 0 {

--- a/src/genx/generate_instructions.rs
+++ b/src/genx/generate_instructions.rs
@@ -22,10 +22,10 @@ use crate::instruction::{
     ToggleShedTailingInstruction, ToggleTrickRoomInstruction,
 };
 use crate::instruction::{ChangeAbilityInstruction, ToggleTerastallizedInstruction};
-use crate::instruction::{DecrementFutureSightInstruction, FormeChangeInstruction};
+use crate::instruction::{DecrementFutureAttackInstruction, FormeChangeInstruction};
 use crate::instruction::{DecrementPPInstruction, SetLastUsedMoveInstruction};
 
-use super::damage_calc::calculate_futuresight_damage;
+use super::damage_calc::calculate_future_attack_damage;
 use super::damage_calc::{calculate_damage, type_effectiveness_modifier, DamageRolls};
 use super::items::{
     item_before_move, item_end_of_turn, item_modify_attack_against, item_modify_attack_being_used,
@@ -3010,32 +3010,32 @@ fn add_end_of_turn_instructions(
     // future sight
     for side_ref in sides {
         let (attacking_side, defending_side) = state.get_both_sides(side_ref);
-        if attacking_side.future_sight.0 > 0 {
-            let decrement_future_sight_instruction =
-                Instruction::DecrementFutureSight(DecrementFutureSightInstruction {
+        if attacking_side.future_attack.turns_remaining > 0 {
+            let decrement_future_attack_instruction =
+                Instruction::DecrementFutureAttack(DecrementFutureAttackInstruction {
                     side_ref: *side_ref,
                 });
-            if attacking_side.future_sight.0 == 1 {
-                let mut damage = calculate_futuresight_damage(
+            if attacking_side.future_attack.turns_remaining == 1 {
+                let mut damage = calculate_future_attack_damage(
                     &attacking_side,
                     &defending_side,
-                    &attacking_side.future_sight.1,
+                    &attacking_side.future_attack.pokemon_index,
                 );
                 let defender = defending_side.get_active();
                 damage = cmp::min(damage, defender.hp);
-                let future_sight_damage_instruction = Instruction::Damage(DamageInstruction {
+                let future_attack_damage_instruction = Instruction::Damage(DamageInstruction {
                     side_ref: side_ref.get_other_side(),
                     damage_amount: damage,
                 });
                 incoming_instructions
                     .instruction_list
-                    .push(future_sight_damage_instruction);
+                    .push(future_attack_damage_instruction);
                 defender.hp -= damage;
             }
-            attacking_side.future_sight.0 -= 1;
+            attacking_side.future_attack.turns_remaining -= 1;
             incoming_instructions
                 .instruction_list
-                .push(decrement_future_sight_instruction);
+                .push(decrement_future_attack_instruction);
         }
     }
 
@@ -4467,8 +4467,8 @@ pub fn calculate_damage_rolls(
         &mut incoming_instructions,
     );
 
-    if choice.move_id == Choices::FUTURESIGHT {
-        choice = MOVES.get(&Choices::FUTURESIGHT)?.clone();
+    if choice.move_id == Choices::FUTURESIGHT || choice.move_id == Choices::DOOMDESIRE {
+        choice = MOVES.get(&choice.move_id)?.clone();
     }
 
     let mut return_vec = Vec::with_capacity(4);

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -68,8 +68,8 @@ pub enum Instruction {
     EnableMove(EnableMoveInstruction),
     ChangeWish(ChangeWishInstruction),
     DecrementWish(DecrementWishInstruction),
-    SetFutureSight(SetFutureSightInstruction),
-    DecrementFutureSight(DecrementFutureSightInstruction),
+    SetFutureAttack(SetFutureAttackInstruction),
+    DecrementFutureAttack(DecrementFutureAttackInstruction),
     DamageSubstitute(DamageInstruction),
     DecrementRestTurns(DecrementRestTurnsInstruction),
     SetRestTurns(SetSleepTurnsInstruction),
@@ -226,15 +226,15 @@ impl fmt::Debug for Instruction {
             Instruction::DecrementWish(d) => {
                 write!(f, "DecrementWish {:?}", d.side_ref)
             }
-            Instruction::SetFutureSight(s) => {
+            Instruction::SetFutureAttack(s) => {
                 write!(
                     f,
-                    "SetFutureSight {:?}: {:?} -> {:?}",
-                    s.side_ref, s.previous_pokemon_index, s.pokemon_index
+                    "SetFutureAttack {:?}: {:?} -> {:?} ({:?})",
+                    s.side_ref, s.previous_pokemon_index, s.pokemon_index, s.move_id
                 )
             }
-            Instruction::DecrementFutureSight(d) => {
-                write!(f, "DecrementFutureSight {:?}", d.side_ref)
+            Instruction::DecrementFutureAttack(d) => {
+                write!(f, "DecrementFutureAttack {:?}", d.side_ref)
             }
             Instruction::DamageSubstitute(d) => {
                 write!(
@@ -428,15 +428,47 @@ pub struct DecrementWishInstruction {
     pub side_ref: SideReference,
 }
 
-#[derive(Debug, PartialEq, Clone)]
-pub struct SetFutureSightInstruction {
-    pub side_ref: SideReference,
-    pub pokemon_index: PokemonIndex,
-    pub previous_pokemon_index: PokemonIndex,
+/// Compact encoding for the delayed-attack slot (Future Sight / Doom Desire).
+/// Kept as `u8` so `SetFutureAttackInstruction` fits in a 6-byte `Instruction`.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
+pub enum FutureAttackKind {
+    None = 0,
+    FutureSight = 1,
+    DoomDesire = 2,
+}
+
+impl From<Choices> for FutureAttackKind {
+    fn from(choice: Choices) -> Self {
+        match choice {
+            Choices::FUTURESIGHT => FutureAttackKind::FutureSight,
+            Choices::DOOMDESIRE => FutureAttackKind::DoomDesire,
+            _ => FutureAttackKind::None,
+        }
+    }
+}
+
+impl From<FutureAttackKind> for Choices {
+    fn from(kind: FutureAttackKind) -> Self {
+        match kind {
+            FutureAttackKind::None => Choices::NONE,
+            FutureAttackKind::FutureSight => Choices::FUTURESIGHT,
+            FutureAttackKind::DoomDesire => Choices::DOOMDESIRE,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub struct DecrementFutureSightInstruction {
+pub struct SetFutureAttackInstruction {
+    pub side_ref: SideReference,
+    pub pokemon_index: PokemonIndex,
+    pub previous_pokemon_index: PokemonIndex,
+    pub move_id: FutureAttackKind,
+    pub previous_move_id: FutureAttackKind,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct DecrementFutureAttackInstruction {
     pub side_ref: SideReference,
 }
 
@@ -594,6 +626,7 @@ pub struct ChangeAbilityInstruction {
 #[cfg(test)]
 mod test {
     use super::Instruction;
+    use std::mem::{align_of, size_of};
 
     // Make sure that the size of the Instruction enum doesn't change
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -525,7 +525,11 @@ impl Default for Side {
             volatile_status_durations: VolatileStatusDurations::default(),
             volatile_statuses: VolatileStatusBitset::default(),
             wish: (0, 0),
-            future_sight: (0, PokemonIndex::P0),
+            future_attack: FutureAttack {
+                turns_remaining: 0,
+                pokemon_index: PokemonIndex::P0,
+                move_id: Choices::NONE,
+            },
             force_switch: false,
             slow_uturn_move: false,
             force_trapped: false,
@@ -1052,6 +1056,13 @@ impl Pokemon {
     }
 }
 
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct FutureAttack {
+    pub turns_remaining: i8,
+    pub pokemon_index: PokemonIndex,
+    pub move_id: Choices,
+}
+
 #[derive(Debug, Clone)]
 pub struct Side {
     pub active_index: PokemonIndex,
@@ -1061,7 +1072,7 @@ pub struct Side {
     pub side_conditions: SideConditions,
     pub volatile_status_durations: VolatileStatusDurations,
     pub wish: (i8, i16),
-    pub future_sight: (i8, PokemonIndex),
+    pub future_attack: FutureAttack,
     pub force_switch: bool,
     pub force_trapped: bool,
     pub slow_uturn_move: bool,
@@ -1087,10 +1098,12 @@ impl Side {
         if self.wish.0 != 0 {
             output.push_str(&format!("\n  wish: ({}, {})", self.wish.0, self.wish.1));
         }
-        if self.future_sight.0 != 0 {
+        if self.future_attack.turns_remaining != 0 {
             output.push_str(&format!(
-                "\n  future_sight: ({}, {:?})",
-                self.future_sight.0, self.pokemon[self.future_sight.1].id
+                "\n  future_attack: ({}, {:?}, {:?})",
+                self.future_attack.turns_remaining,
+                self.pokemon[self.future_attack.pokemon_index].id,
+                self.future_attack.move_id
             ));
         }
         if self
@@ -1155,7 +1168,7 @@ impl Side {
             remaining &= remaining - 1;
         }
         format!(
-            "{}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}",
+            "{}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}={}",
             self.pokemon.pkmn[0].serialize(),
             self.pokemon.pkmn[1].serialize(),
             self.pokemon.pkmn[2].serialize(),
@@ -1176,8 +1189,9 @@ impl Side {
             self.evasion_boost,
             self.wish.0,
             self.wish.1,
-            self.future_sight.0,
-            self.future_sight.1.serialize(),
+            self.future_attack.turns_remaining,
+            self.future_attack.pokemon_index.serialize(),
+            self.future_attack.move_id.to_string(),
             self.force_switch,
             self.switch_out_move_second_saved_move.to_string(),
             self.baton_passing,
@@ -1223,18 +1237,19 @@ impl Side {
                 split[18].parse::<i8>().unwrap(),
                 split[19].parse::<i16>().unwrap(),
             ),
-            future_sight: (
-                split[20].parse::<i8>().unwrap(),
-                PokemonIndex::deserialize(split[21]),
-            ),
-            force_switch: split[22].parse::<bool>().unwrap(),
-            switch_out_move_second_saved_move: Choices::from_str(split[23]).unwrap(),
-            baton_passing: split[24].parse::<bool>().unwrap(),
-            shed_tailing: split[25].parse::<bool>().unwrap(),
-            force_trapped: split[26].parse::<bool>().unwrap(),
-            last_used_move: LastUsedMove::deserialize(split[27]),
+            future_attack: FutureAttack {
+                turns_remaining: split[20].parse::<i8>().unwrap(),
+                pokemon_index: PokemonIndex::deserialize(split[21]),
+                move_id: Choices::from_str(split[22]).unwrap(),
+            },
+            force_switch: split[23].parse::<bool>().unwrap(),
+            switch_out_move_second_saved_move: Choices::from_str(split[24]).unwrap(),
+            baton_passing: split[25].parse::<bool>().unwrap(),
+            shed_tailing: split[26].parse::<bool>().unwrap(),
+            force_trapped: split[27].parse::<bool>().unwrap(),
+            last_used_move: LastUsedMove::deserialize(split[28]),
             damage_dealt: DamageDealt::default(),
-            slow_uturn_move: split[28].parse::<bool>().unwrap(),
+            slow_uturn_move: split[29].parse::<bool>().unwrap(),
         }
     }
 }
@@ -1687,28 +1702,36 @@ impl State {
         self.get_side(side_reference).wish.0 -= 1;
     }
 
-    fn set_future_sight(&mut self, side_reference: &SideReference, pokemon_index: PokemonIndex) {
+    fn set_future_attack(
+        &mut self,
+        side_reference: &SideReference,
+        pokemon_index: PokemonIndex,
+        move_id: Choices,
+    ) {
         let side = self.get_side(side_reference);
-        side.future_sight.0 = 3;
-        side.future_sight.1 = pokemon_index;
+        side.future_attack.turns_remaining = 3;
+        side.future_attack.pokemon_index = pokemon_index;
+        side.future_attack.move_id = move_id;
     }
 
-    fn unset_future_sight(
+    fn unset_future_attack(
         &mut self,
         side_reference: &SideReference,
         previous_pokemon_index: PokemonIndex,
+        previous_move_id: Choices,
     ) {
         let side = self.get_side(side_reference);
-        side.future_sight.0 = 0;
-        side.future_sight.1 = previous_pokemon_index;
+        side.future_attack.turns_remaining = 0;
+        side.future_attack.pokemon_index = previous_pokemon_index;
+        side.future_attack.move_id = previous_move_id;
     }
 
-    fn increment_future_sight(&mut self, side_reference: &SideReference) {
-        self.get_side(side_reference).future_sight.0 += 1;
+    fn increment_future_attack(&mut self, side_reference: &SideReference) {
+        self.get_side(side_reference).future_attack.turns_remaining += 1;
     }
 
-    fn decrement_future_sight(&mut self, side_reference: &SideReference) {
-        self.get_side(side_reference).future_sight.0 -= 1;
+    fn decrement_future_attack(&mut self, side_reference: &SideReference) {
+        self.get_side(side_reference).future_attack.turns_remaining -= 1;
     }
 
     fn damage_substitute(&mut self, side_reference: &SideReference, amount: i16) {
@@ -1890,11 +1913,15 @@ impl State {
             Instruction::DecrementWish(instruction) => {
                 self.decrement_wish(&instruction.side_ref);
             }
-            Instruction::SetFutureSight(instruction) => {
-                self.set_future_sight(&instruction.side_ref, instruction.pokemon_index);
+            Instruction::SetFutureAttack(instruction) => {
+                self.set_future_attack(
+                    &instruction.side_ref,
+                    instruction.pokemon_index,
+                    instruction.move_id.into(),
+                );
             }
-            Instruction::DecrementFutureSight(instruction) => {
-                self.decrement_future_sight(&instruction.side_ref);
+            Instruction::DecrementFutureAttack(instruction) => {
+                self.decrement_future_attack(&instruction.side_ref);
             }
             Instruction::DamageSubstitute(instruction) => {
                 self.damage_substitute(&instruction.side_ref, instruction.damage_amount);
@@ -2092,11 +2119,15 @@ impl State {
                 self.unset_wish(&instruction.side_ref, instruction.wish_amount_change)
             }
             Instruction::DecrementWish(instruction) => self.increment_wish(&instruction.side_ref),
-            Instruction::SetFutureSight(instruction) => {
-                self.unset_future_sight(&instruction.side_ref, instruction.previous_pokemon_index)
+            Instruction::SetFutureAttack(instruction) => {
+                self.unset_future_attack(
+                    &instruction.side_ref,
+                    instruction.previous_pokemon_index,
+                    instruction.previous_move_id.into(),
+                )
             }
-            Instruction::DecrementFutureSight(instruction) => {
-                self.increment_future_sight(&instruction.side_ref)
+            Instruction::DecrementFutureAttack(instruction) => {
+                self.increment_future_attack(&instruction.side_ref)
             }
             Instruction::DamageSubstitute(instruction) => {
                 self.heal_substitute(&instruction.side_ref, instruction.damage_amount);
@@ -2357,9 +2388,10 @@ impl State {
     /// "0=",
     /// "0=",
     ///
-    /// // future sight is represented by the PokemonIndex of the pokemon that used futuresight, and the number of turns remaining until it hits
+    /// // future attack is turns remaining, PokemonIndex of the user, and move id (futuresight / doomdesire / none)
     /// "0=",
     /// "0=",
+    /// "none=",
     ///
     /// // a boolean representing if the side is forced to switch
     /// "false=",
@@ -2384,7 +2416,7 @@ impl State {
     /// "false/",
     ///
     /// // SIDE 2, all in one line for brevity
-    /// "terrakion,100,Rock,Fighting,Rock,Fighting,323,323,NONE,NONE,FOCUSSASH,SERIOUS,,357,216,163,217,346,None,0,0,25.5,CLOSECOMBAT;false;8,STONEEDGE;false;8,STEALTHROCK;false;32,TAUNT;false;32,false,false,normal=lucario,100,Fighting,Steel,Fighting,Steel,281,281,NONE,NONE,LIFEORB,SERIOUS,,350,176,241,177,279,None,0,0,25.5,CLOSECOMBAT;false;8,EXTREMESPEED;false;8,SWORDSDANCE;false;32,CRUNCH;false;24,false,false,normal=breloom,100,Grass,Fighting,Grass,Fighting,262,262,TECHNICIAN,TECHNICIAN,LIFEORB,SERIOUS,,394,196,141,156,239,None,0,0,25.5,MACHPUNCH;false;48,BULLETSEED;false;48,SWORDSDANCE;false;32,LOWSWEEP;false;32,false,false,normal=keldeo,100,Water,Fighting,Water,Fighting,323,323,NONE,NONE,LEFTOVERS,SERIOUS,,163,216,357,217,346,None,0,0,25.5,SECRETSWORD;false;16,HYDROPUMP;false;8,SCALD;false;24,SURF;false;24,false,false,normal=conkeldurr,100,Fighting,Typeless,Fighting,Typeless,414,414,GUTS,GUTS,LEFTOVERS,SERIOUS,,416,226,132,167,126,None,0,0,25.5,MACHPUNCH;false;48,DRAINPUNCH;false;16,ICEPUNCH;false;24,THUNDERPUNCH;false;24,false,false,normal=toxicroak,100,Poison,Fighting,Poison,Fighting,307,307,DRYSKIN,DRYSKIN,LIFEORB,SERIOUS,,311,166,189,167,295,None,0,0,25.5,DRAINPUNCH;false;16,SUCKERPUNCH;false;8,SWORDSDANCE;false;32,ICEPUNCH;false;24,false,false,normal=0=0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;==0;0;0;0;0;0=0=0=0=0=0=0=0=0=0=0=0=0=false=NONE=false=false=false=switch:0=false/",
+    /// "terrakion,100,Rock,Fighting,Rock,Fighting,323,323,NONE,NONE,FOCUSSASH,SERIOUS,,357,216,163,217,346,None,0,0,25.5,CLOSECOMBAT;false;8,STONEEDGE;false;8,STEALTHROCK;false;32,TAUNT;false;32,false,false,normal=lucario,100,Fighting,Steel,Fighting,Steel,281,281,NONE,NONE,LIFEORB,SERIOUS,,350,176,241,177,279,None,0,0,25.5,CLOSECOMBAT;false;8,EXTREMESPEED;false;8,SWORDSDANCE;false;32,CRUNCH;false;24,false,false,normal=breloom,100,Grass,Fighting,Grass,Fighting,262,262,TECHNICIAN,TECHNICIAN,LIFEORB,SERIOUS,,394,196,141,156,239,None,0,0,25.5,MACHPUNCH;false;48,BULLETSEED;false;48,SWORDSDANCE;false;32,LOWSWEEP;false;32,false,false,normal=keldeo,100,Water,Fighting,Water,Fighting,323,323,NONE,NONE,LEFTOVERS,SERIOUS,,163,216,357,217,346,None,0,0,25.5,SECRETSWORD;false;16,HYDROPUMP;false;8,SCALD;false;24,SURF;false;24,false,false,normal=conkeldurr,100,Fighting,Typeless,Fighting,Typeless,414,414,GUTS,GUTS,LEFTOVERS,SERIOUS,,416,226,132,167,126,None,0,0,25.5,MACHPUNCH;false;48,DRAINPUNCH;false;16,ICEPUNCH;false;24,THUNDERPUNCH;false;24,false,false,normal=toxicroak,100,Poison,Fighting,Poison,Fighting,307,307,DRYSKIN,DRYSKIN,LIFEORB,SERIOUS,,311,166,189,167,295,None,0,0,25.5,DRAINPUNCH;false;16,SUCKERPUNCH;false;8,SWORDSDANCE;false;32,ICEPUNCH;false;24,false,false,normal=0=0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;==0;0;0;0;0;0=0=0=0=0=0=0=0=0=0=0=0=0=none=false=NONE=false=false=false=switch:0=false/",
     ///
     /// // weather is a string representing the weather type and the number of turns remaining
     /// "none;5/",
@@ -2411,7 +2443,7 @@ impl State {
     ///
     ///
     /// // the same state, but all in one line
-    /// let serialized_state = "alakazam,100,Psychic,Typeless,Psychic,Typeless,251,251,NONE,NONE,LIFEORB,SERIOUS,252;0;252;0;4;0,121,148,353,206,365,None,0,0,25.5,PSYCHIC;false;16,GRASSKNOT;false;32,SHADOWBALL;false;24,HIDDENPOWERFIRE70;false;24,false,false,normal=skarmory,100,Steel,Flying,Steel,Flying,271,271,STURDY,STURDY,CUSTAPBERRY,SERIOUS,,259,316,104,177,262,None,0,0,25.5,STEALTHROCK;false;32,SPIKES;false;32,BRAVEBIRD;false;24,THIEF;false;40,false,false,normal=tyranitar,100,Rock,Dark,Rock,Dark,404,404,SANDSTREAM,SANDSTREAM,CHOPLEBERRY,SERIOUS,,305,256,203,327,159,None,0,0,25.5,CRUNCH;false;24,SUPERPOWER;false;8,THUNDERWAVE;false;32,PURSUIT;false;32,false,false,normal=mamoswine,100,Ice,Ground,Ice,Ground,362,362,THICKFAT,THICKFAT,NEVERMELTICE,SERIOUS,,392,196,158,176,241,None,0,0,25.5,ICESHARD;false;48,EARTHQUAKE;false;16,SUPERPOWER;false;8,ICICLECRASH;false;16,false,false,normal=jellicent,100,Water,Ghost,Water,Ghost,404,404,WATERABSORB,WATERABSORB,AIRBALLOON,SERIOUS,,140,237,206,246,180,None,0,0,25.5,TAUNT;false;32,NIGHTSHADE;false;24,WILLOWISP;false;24,RECOVER;false;16,false,false,normal=excadrill,100,Ground,Steel,Ground,Steel,362,362,SANDFORCE,SANDFORCE,CHOICESCARF,SERIOUS,,367,156,122,168,302,None,0,0,25.5,EARTHQUAKE;false;16,IRONHEAD;false;24,ROCKSLIDE;false;16,RAPIDSPIN;false;64,false,false,normal=0=0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;==0;0;0;0;0;0=0=0=0=0=0=0=0=0=0=0=0=0=false=NONE=false=false=false=switch:0=false/terrakion,100,Rock,Fighting,Rock,Fighting,323,323,NONE,NONE,FOCUSSASH,SERIOUS,,357,216,163,217,346,None,0,0,25.5,CLOSECOMBAT;false;8,STONEEDGE;false;8,STEALTHROCK;false;32,TAUNT;false;32,false,false,normal=lucario,100,Fighting,Steel,Fighting,Steel,281,281,NONE,NONE,LIFEORB,SERIOUS,,350,176,241,177,279,None,0,0,25.5,CLOSECOMBAT;false;8,EXTREMESPEED;false;8,SWORDSDANCE;false;32,CRUNCH;false;24,false,false,normal=breloom,100,Grass,Fighting,Grass,Fighting,262,262,TECHNICIAN,TECHNICIAN,LIFEORB,SERIOUS,,394,196,141,156,239,None,0,0,25.5,MACHPUNCH;false;48,BULLETSEED;false;48,SWORDSDANCE;false;32,LOWSWEEP;false;32,false,false,normal=keldeo,100,Water,Fighting,Water,Fighting,323,323,NONE,NONE,LEFTOVERS,SERIOUS,,163,216,357,217,346,None,0,0,25.5,SECRETSWORD;false;16,HYDROPUMP;false;8,SCALD;false;24,SURF;false;24,false,false,normal=conkeldurr,100,Fighting,Typeless,Fighting,Typeless,414,414,GUTS,GUTS,LEFTOVERS,SERIOUS,,416,226,132,167,126,None,0,0,25.5,MACHPUNCH;false;48,DRAINPUNCH;false;16,ICEPUNCH;false;24,THUNDERPUNCH;false;24,false,false,normal=toxicroak,100,Poison,Fighting,Poison,Fighting,307,307,DRYSKIN,DRYSKIN,LIFEORB,SERIOUS,,311,166,189,167,295,None,0,0,25.5,DRAINPUNCH;false;16,SUCKERPUNCH;false;8,SWORDSDANCE;false;32,ICEPUNCH;false;24,false,false,normal=0=0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;==0;0;0;0;0;0=0=0=0=0=0=0=0=0=0=0=0=0=false=NONE=false=false=false=switch:0=false/none;5/none;5/false;5/false";
+    /// let serialized_state = "alakazam,100,Psychic,Typeless,Psychic,Typeless,251,251,NONE,NONE,LIFEORB,SERIOUS,252;0;252;0;4;0,121,148,353,206,365,None,0,0,25.5,PSYCHIC;false;16,GRASSKNOT;false;32,SHADOWBALL;false;24,HIDDENPOWERFIRE70;false;24,false,false,normal=skarmory,100,Steel,Flying,Steel,Flying,271,271,STURDY,STURDY,CUSTAPBERRY,SERIOUS,,259,316,104,177,262,None,0,0,25.5,STEALTHROCK;false;32,SPIKES;false;32,BRAVEBIRD;false;24,THIEF;false;40,false,false,normal=tyranitar,100,Rock,Dark,Rock,Dark,404,404,SANDSTREAM,SANDSTREAM,CHOPLEBERRY,SERIOUS,,305,256,203,327,159,None,0,0,25.5,CRUNCH;false;24,SUPERPOWER;false;8,THUNDERWAVE;false;32,PURSUIT;false;32,false,false,normal=mamoswine,100,Ice,Ground,Ice,Ground,362,362,THICKFAT,THICKFAT,NEVERMELTICE,SERIOUS,,392,196,158,176,241,None,0,0,25.5,ICESHARD;false;48,EARTHQUAKE;false;16,SUPERPOWER;false;8,ICICLECRASH;false;16,false,false,normal=jellicent,100,Water,Ghost,Water,Ghost,404,404,WATERABSORB,WATERABSORB,AIRBALLOON,SERIOUS,,140,237,206,246,180,None,0,0,25.5,TAUNT;false;32,NIGHTSHADE;false;24,WILLOWISP;false;24,RECOVER;false;16,false,false,normal=excadrill,100,Ground,Steel,Ground,Steel,362,362,SANDFORCE,SANDFORCE,CHOICESCARF,SERIOUS,,367,156,122,168,302,None,0,0,25.5,EARTHQUAKE;false;16,IRONHEAD;false;24,ROCKSLIDE;false;16,RAPIDSPIN;false;64,false,false,normal=0=0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;==0;0;0;0;0;0=0=0=0=0=0=0=0=0=0=0=0=0=none=false=NONE=false=false=false=switch:0=false/terrakion,100,Rock,Fighting,Rock,Fighting,323,323,NONE,NONE,FOCUSSASH,SERIOUS,,357,216,163,217,346,None,0,0,25.5,CLOSECOMBAT;false;8,STONEEDGE;false;8,STEALTHROCK;false;32,TAUNT;false;32,false,false,normal=lucario,100,Fighting,Steel,Fighting,Steel,281,281,NONE,NONE,LIFEORB,SERIOUS,,350,176,241,177,279,None,0,0,25.5,CLOSECOMBAT;false;8,EXTREMESPEED;false;8,SWORDSDANCE;false;32,CRUNCH;false;24,false,false,normal=breloom,100,Grass,Fighting,Grass,Fighting,262,262,TECHNICIAN,TECHNICIAN,LIFEORB,SERIOUS,,394,196,141,156,239,None,0,0,25.5,MACHPUNCH;false;48,BULLETSEED;false;48,SWORDSDANCE;false;32,LOWSWEEP;false;32,false,false,normal=keldeo,100,Water,Fighting,Water,Fighting,323,323,NONE,NONE,LEFTOVERS,SERIOUS,,163,216,357,217,346,None,0,0,25.5,SECRETSWORD;false;16,HYDROPUMP;false;8,SCALD;false;24,SURF;false;24,false,false,normal=conkeldurr,100,Fighting,Typeless,Fighting,Typeless,414,414,GUTS,GUTS,LEFTOVERS,SERIOUS,,416,226,132,167,126,None,0,0,25.5,MACHPUNCH;false;48,DRAINPUNCH;false;16,ICEPUNCH;false;24,THUNDERPUNCH;false;24,false,false,normal=toxicroak,100,Poison,Fighting,Poison,Fighting,307,307,DRYSKIN,DRYSKIN,LIFEORB,SERIOUS,,311,166,189,167,295,None,0,0,25.5,DRAINPUNCH;false;16,SUCKERPUNCH;false;8,SWORDSDANCE;false;32,ICEPUNCH;false;24,false,false,normal=0=0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;==0;0;0;0;0;0=0=0=0=0=0=0=0=0=0=0=0=0=none=false=NONE=false=false=false=switch:0=false/none;5/none;5/false;5/false";
     /// let state2 = State::deserialize(serialized_state);
     /// assert_eq!(state.serialize(), state2.serialize());
     ///

--- a/tests/test_battle_mechanics.rs
+++ b/tests/test_battle_mechanics.rs
@@ -16,10 +16,10 @@ use poke_engine::instruction::{
     ChangeItemInstruction, ChangeSideConditionInstruction, ChangeStatInstruction,
     ChangeStatusInstruction, ChangeSubsituteHealthInstruction, ChangeTerrain, ChangeType,
     ChangeVolatileStatusDurationInstruction, ChangeWeather, ChangeWishInstruction,
-    DamageInstruction, DecrementFutureSightInstruction, DecrementPPInstruction,
+    DamageInstruction, DecrementFutureAttackInstruction, DecrementPPInstruction, FutureAttackKind,
     DecrementRestTurnsInstruction, DecrementWishInstruction, DisableMoveInstruction,
     EnableMoveInstruction, FormeChangeInstruction, HealInstruction, Instruction,
-    RemoveVolatileStatusInstruction, SetFutureSightInstruction, SetLastUsedMoveInstruction,
+    RemoveVolatileStatusInstruction, SetFutureAttackInstruction, SetLastUsedMoveInstruction,
     SetSecondMoveSwitchOutMoveInstruction, SetSleepTurnsInstruction, StateInstructions,
     SwitchInstruction, ToggleBatonPassingInstruction, ToggleMegaEvolvedInstruction,
     ToggleShedTailingInstruction, ToggleTrickRoomInstruction,
@@ -13079,12 +13079,42 @@ fn test_using_futuresight() {
     let expected_instructions = vec![StateInstructions {
         percentage: 100.0,
         instruction_list: vec![
-            Instruction::SetFutureSight(SetFutureSightInstruction {
+            Instruction::SetFutureAttack(SetFutureAttackInstruction {
                 side_ref: SideReference::SideOne,
                 pokemon_index: PokemonIndex::P0,
                 previous_pokemon_index: PokemonIndex::P0,
+                move_id: FutureAttackKind::FutureSight,
+                previous_move_id: FutureAttackKind::None,
             }),
-            Instruction::DecrementFutureSight(DecrementFutureSightInstruction {
+            Instruction::DecrementFutureAttack(DecrementFutureAttackInstruction {
+                side_ref: SideReference::SideOne,
+            }),
+        ],
+    }];
+    assert_eq!(expected_instructions, vec_of_instructions);
+}
+
+#[test]
+fn test_using_doomdesire() {
+    let mut state = State::default();
+
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::DOOMDESIRE,
+        Choices::SPLASH,
+    );
+
+    let expected_instructions = vec![StateInstructions {
+        percentage: 100.0,
+        instruction_list: vec![
+            Instruction::SetFutureAttack(SetFutureAttackInstruction {
+                side_ref: SideReference::SideOne,
+                pokemon_index: PokemonIndex::P0,
+                previous_pokemon_index: PokemonIndex::P0,
+                move_id: FutureAttackKind::DoomDesire,
+                previous_move_id: FutureAttackKind::None,
+            }),
+            Instruction::DecrementFutureAttack(DecrementFutureAttackInstruction {
                 side_ref: SideReference::SideOne,
             }),
         ],
@@ -13095,8 +13125,8 @@ fn test_using_futuresight() {
 #[test]
 fn test_futuresight_decrementing_on_its_own() {
     let mut state = State::default();
-    state.side_one.future_sight.0 = 2;
-    state.side_one.future_sight.1 = PokemonIndex::P0;
+    state.side_one.future_attack.turns_remaining = 2;
+    state.side_one.future_attack.pokemon_index = PokemonIndex::P0;
 
     let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
         &mut state,
@@ -13106,8 +13136,8 @@ fn test_futuresight_decrementing_on_its_own() {
 
     let expected_instructions = vec![StateInstructions {
         percentage: 100.0,
-        instruction_list: vec![Instruction::DecrementFutureSight(
-            DecrementFutureSightInstruction {
+        instruction_list: vec![Instruction::DecrementFutureAttack(
+            DecrementFutureAttackInstruction {
                 side_ref: SideReference::SideOne,
             },
         )],
@@ -13118,8 +13148,9 @@ fn test_futuresight_decrementing_on_its_own() {
 #[test]
 fn test_cannot_use_futuresight_when_it_is_already_active() {
     let mut state = State::default();
-    state.side_one.future_sight.0 = 2;
-    state.side_one.future_sight.1 = PokemonIndex::P0;
+    state.side_one.future_attack.turns_remaining = 2;
+    state.side_one.future_attack.pokemon_index = PokemonIndex::P0;
+    state.side_one.future_attack.move_id = Choices::FUTURESIGHT;
 
     let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
         &mut state,
@@ -13129,8 +13160,56 @@ fn test_cannot_use_futuresight_when_it_is_already_active() {
 
     let expected_instructions = vec![StateInstructions {
         percentage: 100.0,
-        instruction_list: vec![Instruction::DecrementFutureSight(
-            DecrementFutureSightInstruction {
+        instruction_list: vec![Instruction::DecrementFutureAttack(
+            DecrementFutureAttackInstruction {
+                side_ref: SideReference::SideOne,
+            },
+        )],
+    }];
+    assert_eq!(expected_instructions, vec_of_instructions);
+}
+
+#[test]
+fn test_cannot_use_doomdesire_when_futuresight_already_active() {
+    let mut state = State::default();
+    state.side_one.future_attack.turns_remaining = 2;
+    state.side_one.future_attack.pokemon_index = PokemonIndex::P0;
+    state.side_one.future_attack.move_id = Choices::FUTURESIGHT;
+
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::DOOMDESIRE,
+        Choices::SPLASH,
+    );
+
+    let expected_instructions = vec![StateInstructions {
+        percentage: 100.0,
+        instruction_list: vec![Instruction::DecrementFutureAttack(
+            DecrementFutureAttackInstruction {
+                side_ref: SideReference::SideOne,
+            },
+        )],
+    }];
+    assert_eq!(expected_instructions, vec_of_instructions);
+}
+
+#[test]
+fn test_cannot_use_futuresight_when_doomdesire_already_active() {
+    let mut state = State::default();
+    state.side_one.future_attack.turns_remaining = 2;
+    state.side_one.future_attack.pokemon_index = PokemonIndex::P0;
+    state.side_one.future_attack.move_id = Choices::DOOMDESIRE;
+
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::FUTURESIGHT,
+        Choices::SPLASH,
+    );
+
+    let expected_instructions = vec![StateInstructions {
+        percentage: 100.0,
+        instruction_list: vec![Instruction::DecrementFutureAttack(
+            DecrementFutureAttackInstruction {
                 side_ref: SideReference::SideOne,
             },
         )],
@@ -13148,8 +13227,9 @@ fn test_cannot_use_futuresight_when_it_is_already_active() {
 ))] // just so that the damage is correct
 fn test_futuresight_activating() {
     let mut state = State::default();
-    state.side_one.future_sight.0 = 1;
-    state.side_one.future_sight.1 = PokemonIndex::P0;
+    state.side_one.future_attack.turns_remaining = 1;
+    state.side_one.future_attack.pokemon_index = PokemonIndex::P0;
+    state.side_one.future_attack.move_id = Choices::FUTURESIGHT;
 
     let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
         &mut state,
@@ -13164,7 +13244,81 @@ fn test_futuresight_activating() {
                 side_ref: SideReference::SideTwo,
                 damage_amount: 94,
             }),
-            Instruction::DecrementFutureSight(DecrementFutureSightInstruction {
+            Instruction::DecrementFutureAttack(DecrementFutureAttackInstruction {
+                side_ref: SideReference::SideOne,
+            }),
+        ],
+    }];
+    assert_eq!(expected_instructions, vec_of_instructions);
+}
+
+#[test]
+#[cfg(any(
+    feature = "champions",
+    feature = "gen9",
+    feature = "gen8",
+    feature = "gen7",
+    feature = "gen6"
+))] // just so that the damage is correct
+fn test_doomdesire_activating() {
+    let mut state = State::default();
+    state.side_one.future_attack.turns_remaining = 1;
+    state.side_one.future_attack.pokemon_index = PokemonIndex::P0;
+    state.side_one.future_attack.move_id = Choices::DOOMDESIRE;
+
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::SPLASH,
+        Choices::SPLASH,
+    );
+
+    // Doom Desire is Special Steel BP 140 (gen 5+); Future Sight is Psychic BP 120 (94 dmg).
+    // On a Normal target both are neutral, so Doom Desire deals more.
+    let expected_instructions = vec![StateInstructions {
+        percentage: 100.0,
+        instruction_list: vec![
+            Instruction::Damage(DamageInstruction {
+                side_ref: SideReference::SideTwo,
+                damage_amount: 100,
+            }),
+            Instruction::DecrementFutureAttack(DecrementFutureAttackInstruction {
+                side_ref: SideReference::SideOne,
+            }),
+        ],
+    }];
+    assert_eq!(expected_instructions, vec_of_instructions);
+}
+
+#[test]
+#[cfg(any(
+    feature = "champions",
+    feature = "gen9",
+    feature = "gen8",
+    feature = "gen7",
+    feature = "gen6"
+))] // just so that the damage is correct
+fn test_doomdesire_activating_is_steel_type() {
+    let mut state = State::default();
+    state.side_one.future_attack.turns_remaining = 1;
+    state.side_one.future_attack.pokemon_index = PokemonIndex::P0;
+    state.side_one.future_attack.move_id = Choices::DOOMDESIRE;
+    // Fire resists Steel; Psychic would be neutral into Fire.
+    state.side_two.get_active().types = (PokemonType::FIRE, PokemonType::TYPELESS);
+
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::SPLASH,
+        Choices::SPLASH,
+    );
+
+    let expected_instructions = vec![StateInstructions {
+        percentage: 100.0,
+        instruction_list: vec![
+            Instruction::Damage(DamageInstruction {
+                side_ref: SideReference::SideTwo,
+                damage_amount: 55,
+            }),
+            Instruction::DecrementFutureAttack(DecrementFutureAttackInstruction {
                 side_ref: SideReference::SideOne,
             }),
         ],
@@ -13182,8 +13336,9 @@ fn test_futuresight_activating() {
 ))] // just so that the damage is correct
 fn test_futuresight_activating_on_reserve_pkmn() {
     let mut state = State::default();
-    state.side_one.future_sight.0 = 1;
-    state.side_one.future_sight.1 = PokemonIndex::P1;
+    state.side_one.future_attack.turns_remaining = 1;
+    state.side_one.future_attack.pokemon_index = PokemonIndex::P1;
+    state.side_one.future_attack.move_id = Choices::FUTURESIGHT;
     state.side_one.pokemon[PokemonIndex::P1].special_attack = 10; // very weak
 
     let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
@@ -13199,7 +13354,7 @@ fn test_futuresight_activating_on_reserve_pkmn() {
                 side_ref: SideReference::SideTwo,
                 damage_amount: 11,
             }),
-            Instruction::DecrementFutureSight(DecrementFutureSightInstruction {
+            Instruction::DecrementFutureAttack(DecrementFutureAttackInstruction {
                 side_ref: SideReference::SideOne,
             }),
         ],

--- a/tests/test_gen3.rs
+++ b/tests/test_gen3.rs
@@ -8,13 +8,15 @@ use poke_engine::engine::state::{MoveChoice, PokemonVolatileStatus, Weather};
 use poke_engine::instruction::ChangeSideConditionInstruction;
 use poke_engine::instruction::{
     ApplyVolatileStatusInstruction, ChangeItemInstruction, ChangeStatusInstruction,
-    ChangeVolatileStatusDurationInstruction, DamageInstruction, EnableMoveInstruction,
-    HealInstruction, Instruction, RemoveVolatileStatusInstruction, SetSleepTurnsInstruction,
+    ChangeVolatileStatusDurationInstruction, DamageInstruction, DecrementFutureAttackInstruction,
+    EnableMoveInstruction, FutureAttackKind, HealInstruction, Instruction,
+    RemoveVolatileStatusInstruction, SetFutureAttackInstruction, SetSleepTurnsInstruction,
     StateInstructions, SwitchInstruction,
 };
 use poke_engine::state::PokemonSideCondition;
 use poke_engine::state::{
-    Move, PokemonIndex, PokemonMoveIndex, PokemonStatus, PokemonType, SideReference, State,
+    FutureAttack, Move, PokemonIndex, PokemonMoveIndex, PokemonStatus, PokemonType, SideReference,
+    State,
 };
 
 pub fn generate_instructions_with_state_assertion(
@@ -578,5 +580,151 @@ fn test_gen3_branch_when_a_roll_can_kill() {
             })],
         },
     ];
+    assert_eq!(expected_instructions, vec_of_instructions);
+}
+
+#[test]
+fn test_using_doomdesire_does_not_damage_immediately() {
+    let mut state = State::default();
+
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::DOOMDESIRE,
+        Choices::SPLASH,
+    );
+
+    let expected_instructions = vec![StateInstructions {
+        percentage: 100.0,
+        instruction_list: vec![
+            Instruction::SetFutureAttack(SetFutureAttackInstruction {
+                side_ref: SideReference::SideOne,
+                pokemon_index: PokemonIndex::P0,
+                previous_pokemon_index: PokemonIndex::P0,
+                move_id: FutureAttackKind::DoomDesire,
+                previous_move_id: FutureAttackKind::None,
+            }),
+            Instruction::DecrementFutureAttack(DecrementFutureAttackInstruction {
+                side_ref: SideReference::SideOne,
+            }),
+        ],
+    }];
+    assert_eq!(expected_instructions, vec_of_instructions);
+}
+
+#[test]
+fn test_doomdesire_activating_uses_steel() {
+    let mut state = State::default();
+    state.side_one.future_attack = FutureAttack {
+        turns_remaining: 1,
+        pokemon_index: PokemonIndex::P0,
+        move_id: Choices::DOOMDESIRE,
+    };
+
+    let doomdesire_damage = {
+        let instructions = set_moves_on_pkmn_and_call_generate_instructions(
+            &mut state,
+            Choices::SPLASH,
+            Choices::SPLASH,
+        );
+        instructions
+            .iter()
+            .flat_map(|branch| branch.instruction_list.iter())
+            .find_map(|i| match i {
+                Instruction::Damage(d) if d.side_ref == SideReference::SideTwo => {
+                    Some(d.damage_amount)
+                }
+                _ => None,
+            })
+            .expect("doom desire should deal damage on landing")
+    };
+
+    let mut state = State::default();
+    state.side_one.future_attack = FutureAttack {
+        turns_remaining: 1,
+        pokemon_index: PokemonIndex::P0,
+        move_id: Choices::FUTURESIGHT,
+    };
+    let futuresight_damage = {
+        let instructions = set_moves_on_pkmn_and_call_generate_instructions(
+            &mut state,
+            Choices::SPLASH,
+            Choices::SPLASH,
+        );
+        instructions
+            .iter()
+            .flat_map(|branch| branch.instruction_list.iter())
+            .find_map(|i| match i {
+                Instruction::Damage(d) if d.side_ref == SideReference::SideTwo => {
+                    Some(d.damage_amount)
+                }
+                _ => None,
+            })
+            .expect("future sight should deal damage on landing")
+    };
+
+    // Gen3: Doom Desire is Steel BP 120; Future Sight is Psychic BP 80.
+    assert!(
+        doomdesire_damage > futuresight_damage,
+        "doom desire (bp 120) should outdamage future sight (bp 80): {} vs {}",
+        doomdesire_damage,
+        futuresight_damage
+    );
+
+    let mut state = State::default();
+    state.side_one.future_attack = FutureAttack {
+        turns_remaining: 1,
+        pokemon_index: PokemonIndex::P0,
+        move_id: Choices::DOOMDESIRE,
+    };
+    state.side_two.get_active().types = (PokemonType::FIRE, PokemonType::TYPELESS);
+    let steel_into_fire = {
+        let instructions = set_moves_on_pkmn_and_call_generate_instructions(
+            &mut state,
+            Choices::SPLASH,
+            Choices::SPLASH,
+        );
+        instructions
+            .iter()
+            .flat_map(|branch| branch.instruction_list.iter())
+            .find_map(|i| match i {
+                Instruction::Damage(d) if d.side_ref == SideReference::SideTwo => {
+                    Some(d.damage_amount)
+                }
+                _ => None,
+            })
+            .expect("doom desire should deal damage on landing")
+    };
+
+    assert!(
+        steel_into_fire < doomdesire_damage,
+        "steel into fire should deal less than steel into normal: {} vs {}",
+        steel_into_fire,
+        doomdesire_damage
+    );
+}
+
+#[test]
+fn test_cannot_stack_doomdesire_with_futuresight() {
+    let mut state = State::default();
+    state.side_one.future_attack = FutureAttack {
+        turns_remaining: 2,
+        pokemon_index: PokemonIndex::P0,
+        move_id: Choices::FUTURESIGHT,
+    };
+
+    let vec_of_instructions = set_moves_on_pkmn_and_call_generate_instructions(
+        &mut state,
+        Choices::DOOMDESIRE,
+        Choices::SPLASH,
+    );
+
+    let expected_instructions = vec![StateInstructions {
+        percentage: 100.0,
+        instruction_list: vec![Instruction::DecrementFutureAttack(
+            DecrementFutureAttackInstruction {
+                side_ref: SideReference::SideOne,
+            },
+        )],
+    }];
     assert_eq!(expected_instructions, vec_of_instructions);
 }


### PR DESCRIPTION
- Fix Doom Desire by storing which delayed move is queued (Future Sight or Doom Desire) on the future_attack slot (instead of always resolving as Future Sight).
- Landing damage now uses the stored move’s BP and typing; both moves share one slot and cannot stack.
- Rename the old future_sight state/instructions to future_attack, pack the move on SetFutureAttack as a compact FutureAttackKind so Instruction stays 6 bytes
- Update Python bindings plus serialization/doctest samples.